### PR TITLE
fix(cli): accept package name with version suffix in remove command

### DIFF
--- a/.changeset/fix-package-removal-with-version.md
+++ b/.changeset/fix-package-removal-with-version.md
@@ -1,0 +1,5 @@
+---
+"@neuledge/context": patch
+---
+
+Fix CLI `remove` command to accept package names with version suffix (e.g., `next@v16.2.0`). Previously, only the package name without version worked.

--- a/packages/context/src/cli.ts
+++ b/packages/context/src/cli.ts
@@ -500,14 +500,18 @@ program
 program
   .command("remove")
   .description("Remove a documentation package")
-  .argument("<name>", "Package name (without version)")
+  .argument("<name>", "Package name (e.g., 'next' or 'next@v16.2.0')")
   .action((name: string) => {
     const store = new PackageStore();
     loadPackages(store);
 
-    const pkg = store.get(name);
+    // Strip version suffix if present (e.g., "next@v16.2.0" -> "next")
+    const atIndex = name.indexOf("@");
+    const packageName = atIndex > 0 ? name.slice(0, atIndex) : name;
+
+    const pkg = store.get(packageName);
     if (!pkg) {
-      console.error(`Error: Package not found: ${name}`);
+      console.error(`Error: Package not found: ${packageName}`);
       process.exit(1);
     }
 


### PR DESCRIPTION
When listing packages, the CLI shows "next@v16.2.0-canary.23" format.
Users could copy-paste this but the remove command would fail with
"package not found". Now the remove command strips the version suffix
before looking up the package.

https://claude.ai/code/session_01ECRABW6hj1AAdbtoAu2Z5r