### PR TITLE
fix: skip prerelease versions when detecting latest stable tag

### DIFF
--- a/.changeset/fix-nextjs-prerelease-version.md
+++ b/.changeset/fix-nextjs-prerelease-version.md
@@ -1,0 +1,9 @@
+---
+"@neuledge/context": patch
+---
+
+Fix version detection to skip prerelease tags
+
+When auto-detecting version from git tags, the code now properly identifies and skips prerelease versions (canary, alpha, beta, rc, etc.) and finds the highest stable version by semantic versioning.
+
+Previously, adding a repository like Next.js would incorrectly pick a canary version (e.g., v16.2.0-canary.23) instead of the latest stable release (e.g., v16.1.6).


### PR DESCRIPTION
When auto-detecting version from git tags, the code now properly:
- Fetches all tags from remote (needed for shallow clones)
- Parses versions using semver pattern
- Filters out prerelease versions (canary, alpha, beta, rc, etc.)
- Finds the highest stable version by semantic versioning
- Checks out to the detected tag so the code matches the version

Previously, adding a repository like Next.js would incorrectly pick a
canary version (e.g., v16.2.0-canary.23) instead of the latest stable
release (e.g., v16.1.6).

https://claude.ai/code/session_01FNPSjySmD2jA1tXv73zh3U