### PR TITLE
Sync CLI version with package.json instead of hardcoded value

### DIFF
--- a/.changeset/sync-cli-server-version.md
+++ b/.changeset/sync-cli-server-version.md
@@ -1,0 +1,5 @@
+---
+"@neuledge/context": patch
+---
+
+Fix CLI version to read from package.json instead of hardcoded value, keeping it in sync with server version

--- a/packages/context/src/cli.ts
+++ b/packages/context/src/cli.ts
@@ -10,10 +10,15 @@ import {
   statSync,
   unlinkSync,
 } from "node:fs";
+import { createRequire } from "node:module";
 import { homedir } from "node:os";
 import { basename, join, resolve } from "node:path";
 import { pipeline } from "node:stream/promises";
 import { Command } from "commander";
+
+const require = createRequire(import.meta.url);
+const { version } = require("../package.json") as { version: string };
+
 import {
   cloneRepository,
   detectLocalDocsFolder,
@@ -181,7 +186,7 @@ function loadPackages(store: PackageStore): void {
 const program = new Command()
   .name("context")
   .description("Local-first documentation for AI agents")
-  .version("0.1.0");
+  .version(version);
 
 /** Install a package from a local file path. */
 function addFromFile(source: string, options: { save?: string }): void {


### PR DESCRIPTION
## Summary
This PR fixes the CLI version to be dynamically read from `package.json` instead of using a hardcoded value, ensuring the CLI version stays in sync with the server version automatically.

## Changes
- Updated `packages/context/src/cli.ts` to dynamically import the version from `package.json` using `createRequire`
- Replaced the hardcoded version string `"0.1.0"` with the dynamically loaded `version` variable
- Added changeset entry documenting this patch fix

## Implementation Details
- Used Node.js `createRequire` from the `node:module` module to enable CommonJS `require()` in an ES module context
- The version is now read at module load time from the package manifest, eliminating the need to manually update the version string in the code when releasing new versions
- This approach ensures the CLI version will always match the package version without additional maintenance overhead

https://claude.ai/code/session_01PhQ3Zes2kR2pYuAcnXYNvg