### PR TITLE
fix: deduplicate sections with identical title and content across files

### DIFF
--- a/.changeset/fix-duplicate-sections.md
+++ b/.changeset/fix-duplicate-sections.md
@@ -1,0 +1,7 @@
+---
+"@neuledge/context": patch
+---
+
+Fix duplicate sections appearing when scanning repos with identical content across multiple files
+
+Sections with the same title and content from different source files (e.g., shared README sections across package directories) are now deduplicated, keeping only the first occurrence.

--- a/packages/context/src/package-builder.ts
+++ b/packages/context/src/package-builder.ts
@@ -2,9 +2,20 @@
  * Package builder for creating documentation packages from markdown files.
  */
 
+import { createHash } from "node:crypto";
 import { existsSync, unlinkSync } from "node:fs";
 import Database from "better-sqlite3";
 import { type DocSection, parseMarkdown } from "./build.js";
+
+/**
+ * Generate a content hash for section deduplication.
+ * Uses first 16 chars of MD5 (sufficient for detecting identical content).
+ */
+function sectionHash(section: DocSection): string {
+  // Hash by section title + content to identify duplicates across different files
+  const key = `${section.sectionTitle}\n${section.content}`;
+  return createHash("md5").update(key).digest("hex").slice(0, 16);
+}
 
 export interface PackageBuildOptions {
   name: string;
@@ -79,11 +90,19 @@ export function buildPackage(
     `);
 
     const allSections: DocSection[] = [];
+    const seenHashes = new Set<string>();
 
     for (const file of files) {
       try {
         const parsed = parseMarkdown(file.content, file.path);
-        allSections.push(...parsed.sections);
+        for (const section of parsed.sections) {
+          // Deduplicate sections with identical title + content
+          const hash = sectionHash(section);
+          if (!seenHashes.has(hash)) {
+            seenHashes.add(hash);
+            allSections.push(section);
+          }
+        }
       } catch {
         // Skip files that fail to parse
       }


### PR DESCRIPTION
When scanning repos with multiple files containing the same section (e.g.,
shared README sections like "Skill for Coding Agents" across package directories),
sections with identical title + content are now deduplicated, keeping only the
first occurrence.

https://claude.ai/code/session_01DxdwPdEqad1uepkNcGA2Zj