### PR TITLE
Fix version flag conflict in add command

### DIFF
--- a/.changeset/fix-version-flag-conflict.md
+++ b/.changeset/fix-version-flag-conflict.md
@@ -1,0 +1,5 @@
+---
+"@neuledge/context": patch
+---
+
+Rename `--version` to `--pkg-version` in the `add` command to fix conflict with Commander.js's built-in version flag

--- a/packages/context/README.md
+++ b/packages/context/README.md
@@ -310,12 +310,12 @@ context add ./my-project
 context add /path/to/repo --path docs
 
 # Custom package name and version
-context add ./my-lib --name my-library --version 1.0.0
+context add ./my-lib --name my-library --pkg-version 1.0.0
 ```
 
 | Option | Description |
 |--------|-------------|
-| `--version <version>` | Custom version label |
+| `--pkg-version <version>` | Custom version label |
 | `--path <path>` | Path to docs folder in repo/directory |
 | `--name <name>` | Custom package name |
 | `--save <path>` | Save a copy of the package to the specified path |

--- a/packages/context/src/cli.ts
+++ b/packages/context/src/cli.ts
@@ -583,7 +583,7 @@ program
     "Package source: local .db file, URL (.db), GitHub URL, git URL, or local directory",
   )
   .option("--tag <tag>", "Git tag to checkout (for git repos)")
-  .option("--version <version>", "Custom version label")
+  .option("--pkg-version <version>", "Custom version label")
   .option("--path <path>", "Path to docs folder in repo/directory")
   .option("--name <name>", "Custom package name")
   .option("--save <path>", "Save a copy of the package to the specified path")
@@ -596,7 +596,7 @@ program
       source: string,
       options: {
         tag?: string;
-        version?: string;
+        pkgVersion?: string;
         path?: string;
         name?: string;
         save?: string;
@@ -606,18 +606,24 @@ program
       try {
         const sourceType = detectSourceType(source);
 
+        // Map pkgVersion to version for internal use
+        const internalOptions = {
+          ...options,
+          version: options.pkgVersion,
+        };
+
         switch (sourceType) {
           case "file":
-            addFromFile(source, options);
+            addFromFile(source, internalOptions);
             break;
           case "url":
-            await addFromUrl(source, options);
+            await addFromUrl(source, internalOptions);
             break;
           case "git":
-            await addFromGitClone(source, options);
+            await addFromGitClone(source, internalOptions);
             break;
           case "local-dir":
-            await addFromLocalDir(source, options);
+            await addFromLocalDir(source, internalOptions);
             break;
         }
       } catch (err) {


### PR DESCRIPTION
## Summary
Renamed the `--version` flag to `--pkg-version` in the `add` command to resolve a conflict with Commander.js's built-in `--version` flag, which displays the CLI tool's version.

## Changes
- Renamed `--version` option to `--pkg-version` in the CLI argument parser
- Updated the options interface to use `pkgVersion` instead of `version`
- Added internal mapping to convert `pkgVersion` to `version` before passing to handler functions, maintaining backward compatibility with existing internal APIs
- Updated README documentation and examples to reflect the new flag name

## Implementation Details
The fix uses an internal options mapping approach that:
1. Accepts the new `--pkg-version` flag from users
2. Maps it to the internal `version` property before calling handler functions
3. Preserves the existing internal API without requiring changes to `addFromFile`, `addFromUrl`, `addFromGitClone`, and `addFromLocalDir` functions

This approach minimizes the scope of changes while cleanly separating the public CLI interface from internal implementation.

https://claude.ai/code/session_014uvpqdDUKxPX5ATpWDmLpP