### PR TITLE
fix: deduplicate sections by content only, ignoring titles

### DIFF
--- a/.changeset/fix-duplicate-sections.md
+++ b/.changeset/fix-duplicate-sections.md
@@ -4,4 +4,4 @@
 
 Fix duplicate sections appearing when scanning repos with identical content across multiple files
 
-Sections with the same title and content from different source files (e.g., shared README sections across package directories) are now deduplicated, keeping only the first occurrence.
+Sections with the same content from different source files (e.g., shared README sections across package directories) are now deduplicated based on content only, keeping the first occurrence regardless of section title.

--- a/packages/context/src/package-builder.ts
+++ b/packages/context/src/package-builder.ts
@@ -11,10 +11,8 @@ import { type DocSection, parseMarkdown } from "./build.js";
  * Generate a content hash for section deduplication.
  * Uses first 16 chars of MD5 (sufficient for detecting identical content).
  */
-function sectionHash(section: DocSection): string {
-  // Hash by section title + content to identify duplicates across different files
-  const key = `${section.sectionTitle}\n${section.content}`;
-  return createHash("md5").update(key).digest("hex").slice(0, 16);
+function contentHash(content: string): string {
+  return createHash("md5").update(content).digest("hex").slice(0, 16);
 }
 
 export interface PackageBuildOptions {
@@ -96,8 +94,8 @@ export function buildPackage(
       try {
         const parsed = parseMarkdown(file.content, file.path);
         for (const section of parsed.sections) {
-          // Deduplicate sections with identical title + content
-          const hash = sectionHash(section);
+          // Deduplicate sections with identical content (ignore titles)
+          const hash = contentHash(section.content);
           if (!seenHashes.has(hash)) {
             seenHashes.add(hash);
             allSections.push(section);


### PR DESCRIPTION
Changed deduplication to hash content only instead of title+content.
This catches more duplicates where the same content appears under
different section titles (e.g., "Getting Started" vs "Installation"
with identical content).

https://claude.ai/code/session_012zixb2eigzdSUsU133xqqy