### PR TITLE
Add Claude Code setup instructions to context README

### DIFF
--- a/packages/context/README.md
+++ b/packages/context/README.md
@@ -136,6 +136,15 @@ context add ./my-package.db
 Context works with any MCP-compatible agent. Choose your setup below:
 
 <details>
+<summary><strong>Claude Code</strong></summary>
+
+```bash
+claude mcp add context -- context serve
+```
+
+</details>
+
+<details>
 <summary><strong>Claude Desktop</strong></summary>
 
 Add to your config file:


### PR DESCRIPTION
## Summary
Added setup instructions for Claude Code to the context package README, making it easier for users to integrate the context MCP server with Claude Code.

## Changes
- Added a new collapsible section documenting how to add the context MCP server to Claude Code
- Includes the command: `claude mcp add context -- context serve`
- Positioned before the existing Claude Desktop instructions for logical flow

## Details
This addition provides parity with other MCP-compatible agent setup instructions and helps users quickly get started with the context server in Claude Code environments.

https://claude.ai/code/session_01MKFv3cgaZdi8i1FkeVoA6C