### PR TITLE
Improve get_docs tool description to encourage agent usage

### DIFF
--- a/.changeset/improve-mcp-tool-description.md
+++ b/.changeset/improve-mcp-tool-description.md
@@ -1,0 +1,5 @@
+---
+"@neuledge/context": patch
+---
+
+Improve get_docs tool description to better encourage agent usage

--- a/packages/context/src/server.ts
+++ b/packages/context/src/server.ts
@@ -49,7 +49,7 @@ export class ContextServer {
       "get_docs",
       {
         description:
-          "Retrieves up-to-date documentation for a library. Use this to get accurate, version-specific information about APIs, usage patterns, and best practices. Returns instantly from local cache - no network latency.",
+          "Provides the latest official documentation for installed libraries. Use this as your primary reference when working with library APIs - it contains current, version-specific information that may be more accurate than training data or web searches. Covers API signatures, usage patterns, and best practices. Instant local lookup, no network needed.",
         inputSchema: {
           library: z
             .enum(libraryEnum as [string, ...string[]])


### PR DESCRIPTION
## Summary
Enhanced the `get_docs` tool description in the MCP server to better guide agents toward using it as their primary reference for library documentation.

## Changes
- Updated the `get_docs` tool description to:
  - Emphasize it as the "primary reference" for library APIs
  - Highlight that it contains information potentially more accurate than training data or web searches
  - Clarify the scope (API signatures, usage patterns, best practices)
  - Maintain emphasis on instant local lookup with no network latency

## Details
The improved description is more action-oriented and explicitly encourages agents to prioritize this tool when working with library APIs. This should lead to better agent behavior by making the tool's value proposition clearer and more compelling compared to other information sources.

https://claude.ai/code/session_01N66NMJ4dv5EQheDY1uAXnP