### PR TITLE
include qmd and rmd for documentation source

### DIFF
--- a/packages/context/src/git.ts
+++ b/packages/context/src/git.ts
@@ -393,7 +393,7 @@ function findMarkdownFiles(
             const nameWithoutExt = lowerName.slice(0, -matchingExt.length);
             const nameParts = nameWithoutExt.split(".");
             if (nameParts.length > 1) {
-              const lastPart = nameParts[nameParts.length - 1] || '';
+              const lastPart = nameParts[nameParts.length - 1] || "";
               if (FIXTURE_SUFFIXES.includes(lastPart)) {
                 continue;
               }


### PR DESCRIPTION
Potential documentation written in *.rmd or *.qmd not included in document search. I was attempting to add https://github.com/UKGovernmentBEIS/inspect_ai and the bulk of their documentation was written in [qmd ](https://quarto.org/) as such prior to this PR context only sees the 20 md files rather than the combined 86 md & qmd files.

Implementation details:

- DOCUMENTATION_EXTENSIONS = [".md", ".mdx", ".qmd", ".rmd"]
- FIXTURE_SUFFIXES = ["expect", "test", "spec"]
- Made IGNORED_FILES extension-agnostic by removing file extensions
- Updated file processing logic in findMarkdownFiles to:
	- Check files against all documentation extensions
	- Properly handle ignored file checking for all extensions
	- Check for test fixtures using the suffix array for all extensions (maybe overkill? but seemed more robust this way)


Prior to patch
```
context add https://github.com/UKGovernmentBEIS/inspect_ai
Cloning https://github.com/UKGovernmentBEIS/inspect_ai...
Fetching tags...
✔ Select a tag: HEAD (current main branch)
✔ Package name: inspect-ai
✔ Version: latest
✓ Found docs at /docs
✓ Found 20 markdown files
Building package...
✓ Built package: inspect-ai@latest
✓ Saved to /home/node/.context/packages/inspect-ai@latest.db

Installed: inspect-ai@latest (84.0 KB, 21 sections)

⚠️  Warning: Only 21 sections found (threshold: 50)
   This repository may not contain substantial documentation.
   Many projects keep docs in a separate repository.

   🔍 Search for the docs repo: https://www.google.com/search?q=inspect-ai%20documentation%20site%20github.com

   Or try:
   - Use --path to specify a different docs folder
   - Check for a dedicated docs repo (e.g., inspect-ai-docs, inspect-ai.github.io)
```

Post patch

```
/app/packages/context # node dist/cli.js add https://github.com/UKGovernmentBEIS/inspect_ai
Cloning https://github.com/UKGovernmentBEIS/inspect_ai...
Fetching tags...
✔ Select a tag: HEAD (current main branch)
✔ Package name: inspect-ai
✔ Version: latest
✓ Found docs at /docs
✓ Found 86 markdown files
Building package...
✓ Built package: inspect-ai@latest
✓ Saved to /root/.context/packages/inspect-ai@latest.db

Installed: inspect-ai@latest (1.1 MB, 460 sections)
/app/packages/context #
```


