### PR TITLE
Skip CI when only dot-folder markdown files change

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,9 +4,15 @@ on:
   push:
     branches:
       - main
+    paths-ignore:
+      - '.*/*.md'
+      - '.*/**/*.md'
   pull_request:
     branches:
       - main
+    paths-ignore:
+      - '.*/*.md'
+      - '.*/**/*.md'
 
 jobs:
   lint:


### PR DESCRIPTION
Add paths-ignore to skip CI/CD runs when the only changed files are
markdown files inside directories starting with a dot (e.g. .plans/).

https://claude.ai/code/session_01EZT1WdF17yb2t8zvbt9QSu