### PR TITLE
feat: add reStructuredText (.rst) support via pandoc

### DIFF
--- a/packages/context/src/cli.ts
+++ b/packages/context/src/cli.ts
@@ -457,18 +457,18 @@ async function addFromGitClone(
       console.log(`✓ Reading from repository root`);
     }
 
-    // Read all markdown files (filtered by language)
+    // Read all documentation files (filtered by language)
     const files = readLocalDocsFiles(tempDir, {
       path: docsPath,
       lang: options.lang,
     });
     if (files.length === 0) {
       throw new Error(
-        `No markdown files found${docsPath ? ` in ${docsPath}` : ""}. Use --path to specify or --lang all to include all languages.`,
+        `No documentation files found${docsPath ? ` in ${docsPath}` : ""}. Use --path to specify or --lang all to include all languages.`,
       );
     }
     console.log(
-      `✓ Found ${files.length} markdown files${options.lang ? ` (lang: ${options.lang})` : ""}`,
+      `✓ Found ${files.length} documentation files${options.lang ? ` (lang: ${options.lang})` : ""}`,
     );
 
     // Build the package
@@ -481,6 +481,12 @@ async function addFromGitClone(
       version: versionLabel,
       sourceUrl: url,
     });
+
+    if (result.rstSkipped > 0) {
+      console.log(
+        `⚠️  Skipped ${result.rstSkipped} .rst files (install pandoc to convert reStructuredText)`,
+      );
+    }
 
     console.log(`✓ Built package: ${packageName}@${versionLabel}`);
     console.log(`✓ Saved to ${outputPath}`);
@@ -531,18 +537,18 @@ async function addFromLocalDir(
     console.log(`✓ Reading from directory root`);
   }
 
-  // Read all markdown files (filtered by language)
+  // Read all documentation files (filtered by language)
   const files = readLocalDocsFiles(dirPath, {
     path: docsPath,
     lang: options.lang,
   });
   if (files.length === 0) {
     throw new Error(
-      `No markdown files found${docsPath ? ` in ${docsPath}` : ""}. Use --path to specify or --lang all to include all languages.`,
+      `No documentation files found${docsPath ? ` in ${docsPath}` : ""}. Use --path to specify or --lang all to include all languages.`,
     );
   }
   console.log(
-    `✓ Found ${files.length} markdown files${options.lang ? ` (lang: ${options.lang})` : ""}`,
+    `✓ Found ${files.length} documentation files${options.lang ? ` (lang: ${options.lang})` : ""}`,
   );
 
   // Build the package
@@ -555,6 +561,12 @@ async function addFromLocalDir(
     version: versionLabel,
     sourceUrl: dirPath,
   });
+
+  if (result.rstSkipped > 0) {
+    console.log(
+      `⚠️  Skipped ${result.rstSkipped} .rst files (install pandoc to convert reStructuredText)`,
+    );
+  }
 
   console.log(`✓ Built package: ${packageName}@${versionLabel}`);
   console.log(`✓ Saved to ${outputPath}`);


### PR DESCRIPTION
## Summary

Many major Python libraries use reStructuredText (`.rst`) for documentation instead of Markdown. This PR adds automatic RST-to-Markdown conversion using pandoc during package building, so these libraries can be properly indexed.

- **Auto-detects pandoc** — when installed, `.rst` files are converted transparently
- **Graceful fallback** — without pandoc, `.rst` files are skipped with a helpful warning
- **Only `.rst`** — `.txt` was considered but excluded (too ambiguous across repos)
- **Aligns with #16** — adopts the same `DOCUMENTATION_EXTENSIONS` array pattern and extension-agnostic `IGNORED_FILES`

## Changes

| File | What |
|------|------|
| `git.ts` | Refactored to `DOCUMENTATION_EXTENSIONS` array, extension-agnostic `IGNORED_FILES` and `FIXTURE_SUFFIXES` |
| `package-builder.ts` | Pandoc auto-detection (cached), RST conversion before parsing, `rstSkipped` in `BuildResult` |
| `cli.ts` | Warning when `.rst` files skipped, updated messages to "documentation files" |
| `package-builder.test.ts` | Tests for RST conversion and mixed format handling |

## Real-world results

| Library | Before | After |
|---------|--------|-------|
| Django 5.1 | 1 section | **3,427 sections** |
| SQLAlchemy 2.0 | 0 sections | **2,205 sections** |
| psycopg 3.2 | 0 sections | **220 sections** |
| asyncpg 0.30 | 0 sections | **28 sections** |

## Test plan

- [x] All 72 existing tests pass
- [x] New tests: RST conversion with pandoc, mixed `.md`+`.rst` handling
- [x] TypeScript compiles with zero errors in source files
- [x] Verified with real repos (Django, SQLAlchemy, psycopg, asyncpg)