### PR TITLE
Add test-registry script and fix broken registry definitions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 # auto generated
 dist
 dist-packages
+dist-test
 node_modules
 .turbo
 

--- a/packages/registry/package.json
+++ b/packages/registry/package.json
@@ -7,7 +7,8 @@
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "bin": {
-    "registry": "./dist/cli.js"
+    "registry": "./dist/cli.js",
+    "test-registry": "./dist/test-registry.js"
   },
   "exports": {
     ".": "./dist/index.js"
@@ -16,6 +17,7 @@
     "build": "rimraf --glob dist/** && tsc -p tsconfig.build.json",
     "test": "vitest run",
     "test:watch": "vitest",
+    "test-registry": "tsx src/test-registry.ts",
     "lint": "npx biome ci --error-on-warnings",
     "fix": "npx biome check --write"
   },

--- a/packages/registry/src/build.ts
+++ b/packages/registry/src/build.ts
@@ -65,9 +65,11 @@ export function buildFromDefinition(
   }
 
   const tag = constructTag(entry.tag_pattern, version);
+  // Replace / in scoped names (e.g., @trpc/server → @trpc-server) for valid filenames
+  const safeName = definition.name.replace(/\//g, "-");
   const outputPath = join(
     outputDir,
-    `${definition.registry}-${definition.name}@${version}.db`,
+    `${definition.registry}-${safeName}@${version}.db`,
   );
 
   // Clone the repository at the specific tag
@@ -116,9 +118,10 @@ export function buildUnversioned(
 ): RegistryBuildResult {
   const version = "latest";
   const { source } = definition;
+  const safeName = definition.name.replace(/\//g, "-");
   const outputPath = join(
     outputDir,
-    `${definition.registry}-${definition.name}@${version}.db`,
+    `${definition.registry}-${safeName}@${version}.db`,
   );
 
   // Clone without a specific ref — gets the default branch

--- a/packages/registry/src/test-registry.ts
+++ b/packages/registry/src/test-registry.ts
@@ -1,0 +1,255 @@
+#!/usr/bin/env node
+
+/**
+ * Test registry definitions by running the actual build process.
+ *
+ * - `test <name> [version]`: Build a doc package for one definition
+ * - `report`: Build all definitions and generate a pass/fail report
+ */
+
+import { execSync } from "node:child_process";
+import { mkdirSync, rmSync } from "node:fs";
+import { resolve } from "node:path";
+import { Command } from "commander";
+import {
+  buildFromDefinition,
+  buildUnversioned,
+  type RegistryBuildResult,
+} from "./build.js";
+import {
+  compareSemver,
+  isVersioned,
+  listDefinitions,
+  type PackageDefinition,
+  type VersionEntry,
+} from "./definition.js";
+import { discoverVersions } from "./version-check.js";
+
+const DEFAULT_REGISTRY_DIR = resolve(
+  import.meta.dirname,
+  "../../..",
+  "registry",
+);
+
+const program = new Command()
+  .name("test-registry")
+  .description("Test registry definitions by building doc packages");
+
+program
+  .command("test <name> [version]")
+  .description("Build a doc package for a specific definition")
+  .option("--dir <path>", "Registry directory", DEFAULT_REGISTRY_DIR)
+  .option("--output <path>", "Output directory", "./dist-test")
+  .action(
+    async (
+      name: string,
+      version: string | undefined,
+      opts: { dir: string; output: string },
+    ) => {
+      const definitions = listDefinitions(opts.dir);
+      const def = definitions.find((d) => d.name === name);
+      if (!def) {
+        const available = definitions.map((d) => d.name).join(", ");
+        console.error(
+          `Definition "${name}" not found. Available: ${available}`,
+        );
+        process.exit(1);
+      }
+
+      const result = await buildDefinition(def, opts.output, version);
+      console.log(`  Path:     ${result.path}`);
+      console.log(`  Sections: ${result.sectionCount}`);
+      console.log(`  Tokens:   ${result.totalTokens}`);
+      rmSync(result.path, { force: true });
+    },
+  );
+
+program
+  .command("report")
+  .description("Build all definitions and generate a report")
+  .option("--dir <path>", "Registry directory", DEFAULT_REGISTRY_DIR)
+  .option("--output <path>", "Output directory", "./dist-test")
+  .action(async (opts: { dir: string; output: string }) => {
+    let definitions: PackageDefinition[];
+    try {
+      definitions = listDefinitions(opts.dir);
+    } catch (err) {
+      console.error(
+        "Failed to load definitions:",
+        err instanceof Error ? err.message : err,
+      );
+      process.exit(1);
+    }
+
+    console.log(`Found ${definitions.length} definitions.\n`);
+
+    const results: Array<{
+      name: string;
+      registry: string;
+      status: "pass" | "fail";
+      sections?: number;
+      tokens?: number;
+      version?: string;
+      error?: string;
+    }> = [];
+
+    for (const def of definitions) {
+      const label = `${def.registry}/${def.name}`;
+      try {
+        const result = await buildDefinition(def, opts.output);
+        results.push({
+          name: def.name,
+          registry: def.registry,
+          status: "pass",
+          sections: result.sectionCount,
+          tokens: result.totalTokens,
+          version: result.version,
+        });
+        console.log(
+          `[PASS] ${label}@${result.version}: ${result.sectionCount} sections, ${result.totalTokens} tokens`,
+        );
+        rmSync(result.path, { force: true });
+      } catch (err) {
+        const message = err instanceof Error ? err.message : String(err);
+        results.push({
+          name: def.name,
+          registry: def.registry,
+          status: "fail",
+          error: message,
+        });
+        console.log(`[FAIL] ${label}: ${message}`);
+      }
+    }
+
+    const passed = results.filter((r) => r.status === "pass").length;
+    const failed = results.filter((r) => r.status === "fail").length;
+
+    console.log(`\n${"=".repeat(60)}`);
+    console.log(
+      `Total: ${results.length} | Passed: ${passed} | Failed: ${failed}`,
+    );
+
+    if (failed > 0) {
+      console.log("\nFailed:");
+      for (const r of results.filter((r) => r.status === "fail")) {
+        console.log(`  ${r.registry}/${r.name}: ${r.error}`);
+      }
+      process.exit(1);
+    }
+  });
+
+/**
+ * Build a definition, auto-discovering the version for versioned packages.
+ * Tries npm/pip API first, falls back to scanning git tags.
+ */
+async function buildDefinition(
+  def: PackageDefinition,
+  outputDir: string,
+  requestedVersion?: string,
+): Promise<RegistryBuildResult> {
+  mkdirSync(outputDir, { recursive: true });
+
+  if (!isVersioned(def)) {
+    console.log(`Building ${def.registry}/${def.name}@latest...`);
+    return buildUnversioned(def, outputDir);
+  }
+
+  let version = requestedVersion;
+  if (!version) {
+    // Try registry API first (npm/pip)
+    try {
+      const versions = await discoverVersions(def);
+      if (versions.length > 0) {
+        version = versions[0]?.version;
+      }
+    } catch {
+      // API unavailable, fall through to git tags
+    }
+
+    // Fall back to scanning git tags
+    if (!version) {
+      version = findLatestVersionFromGit(def.versions);
+    }
+
+    if (!version) {
+      throw new Error("No matching version found (checked API and git tags)");
+    }
+  }
+
+  console.log(`Building ${def.registry}/${def.name}@${version}...`);
+  return buildFromDefinition(def, version, outputDir);
+}
+
+/**
+ * Discover the latest version by scanning git remote tags.
+ * Uses pattern-filtered ls-remote to avoid fetching all tags from large monorepos.
+ */
+function findLatestVersionFromGit(entries: VersionEntry[]): string | undefined {
+  let latest: string | undefined;
+
+  for (const entry of entries) {
+    const tags = listRemoteTags(entry.source.url, entry.tag_pattern);
+
+    for (const tag of tags) {
+      const version = extractVersionFromTag(tag, entry.tag_pattern);
+      if (!version) continue;
+      if (compareSemver(version, entry.min_version) < 0) continue;
+      if (entry.max_version && compareSemver(version, entry.max_version) >= 0)
+        continue;
+      if (!latest || compareSemver(version, latest) > 0) {
+        latest = version;
+      }
+    }
+  }
+
+  return latest;
+}
+
+/**
+ * List tags from a git remote, optionally filtered by tag pattern prefix.
+ * Pattern filtering is done server-side (much faster for large monorepos).
+ */
+function listRemoteTags(url: string, tagPattern?: string): string[] {
+  // Extract prefix from tag pattern for server-side filtering
+  // e.g., "effect@{version}" -> "refs/tags/effect@*"
+  const prefix = tagPattern
+    ? tagPattern.slice(0, tagPattern.indexOf("{version}"))
+    : "";
+  const refFilter = prefix ? `"refs/tags/${prefix}*"` : "";
+
+  let output: string;
+  try {
+    output = execSync(`git ls-remote --tags ${url} ${refFilter}`, {
+      encoding: "utf-8",
+      stdio: ["pipe", "pipe", "pipe"],
+      timeout: 60_000,
+    }).trim();
+  } catch {
+    return [];
+  }
+
+  if (!output) return [];
+
+  const tags = new Set<string>();
+  for (const line of output.split("\n")) {
+    const refName = line.split("\t")[1];
+    if (!refName) continue;
+    tags.add(refName.replace("refs/tags/", "").replace(/\^\{\}$/, ""));
+  }
+  return [...tags];
+}
+
+/**
+ * Extract a version from a git tag using a tag pattern.
+ * "v{version}" + "v1.2.3" -> "1.2.3"
+ */
+function extractVersionFromTag(tag: string, tagPattern: string): string | null {
+  const escaped = tagPattern.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+  const regex = new RegExp(
+    `^${escaped.replace("\\{version\\}", "(\\d+\\.\\d+\\.\\d+)")}$`,
+  );
+  const match = tag.match(regex);
+  return match?.[1] ?? null;
+}
+
+await program.parseAsync();

--- a/registry/npm/@trpc/server.yaml
+++ b/registry/npm/@trpc/server.yaml
@@ -8,4 +8,4 @@ versions:
       type: git
       url: https://github.com/trpc/trpc
       docs_path: www/docs
-    tag_pattern: "@trpc/server@{version}"
+    tag_pattern: "v{version}"

--- a/registry/npm/ioredis.yaml
+++ b/registry/npm/ioredis.yaml
@@ -7,5 +7,4 @@ versions:
     source:
       type: git
       url: https://github.com/redis/ioredis
-      docs_path: docs
     tag_pattern: "v{version}"

--- a/registry/npm/knex.yaml
+++ b/registry/npm/knex.yaml
@@ -7,5 +7,4 @@ versions:
     source:
       type: git
       url: https://github.com/knex/knex
-      docs_path: docs
     tag_pattern: "{version}"

--- a/registry/npm/kysely.yaml
+++ b/registry/npm/kysely.yaml
@@ -7,5 +7,5 @@ versions:
     source:
       type: git
       url: https://github.com/kysely-org/kysely
-      docs_path: docs
+      docs_path: site/docs
     tag_pattern: "{version}"

--- a/registry/npm/prettier.yaml
+++ b/registry/npm/prettier.yaml
@@ -8,4 +8,4 @@ versions:
       type: git
       url: https://github.com/prettier/prettier
       docs_path: docs
-    tag_pattern: "v{version}"
+    tag_pattern: "{version}"

--- a/registry/npm/react.yaml
+++ b/registry/npm/react.yaml
@@ -2,10 +2,7 @@ name: react
 description: "A JavaScript library for building user interfaces"
 repository: https://github.com/facebook/react
 
-versions:
-  - min_version: "18.0.0"
-    source:
-      type: git
-      url: https://github.com/reactjs/react.dev
-      docs_path: src/content
-    tag_pattern: "v{version}"
+source:
+  type: git
+  url: https://github.com/reactjs/react.dev
+  docs_path: src/content

--- a/registry/npm/rxjs.yaml
+++ b/registry/npm/rxjs.yaml
@@ -7,5 +7,5 @@ versions:
     source:
       type: git
       url: https://github.com/ReactiveX/rxjs
-      docs_path: apps/rxjs.dev/content
-    tag_pattern: "v{version}"
+      docs_path: docs_app/content
+    tag_pattern: "{version}"

--- a/registry/npm/turbo.yaml
+++ b/registry/npm/turbo.yaml
@@ -5,4 +5,4 @@ repository: https://github.com/vercel/turborepo
 source:
   type: git
   url: https://github.com/vercel/turborepo
-  docs_path: docs
+  docs_path: apps/docs/content

--- a/registry/npm/winston.yaml
+++ b/registry/npm/winston.yaml
@@ -3,9 +3,17 @@ description: "A logger for just about everything"
 repository: https://github.com/winstonjs/winston
 
 versions:
-  - min_version: "3.0.0"
+  - min_version: "3.3.0"
     source:
       type: git
       url: https://github.com/winstonjs/winston
       docs_path: docs
-    tag_pattern: "winston@{version}"
+    tag_pattern: "v{version}"
+
+  - min_version: "3.0.0"
+    max_version: "3.3.0"
+    source:
+      type: git
+      url: https://github.com/winstonjs/winston
+      docs_path: docs
+    tag_pattern: "{version}"


### PR DESCRIPTION
Add a test-registry CLI script that validates registry definitions by
running the actual build process (clone repo, read docs, build .db).
Supports two modes: `test <name>` for single packages and `report` for
all definitions.

Fix broken definitions found by running the report:
- @trpc/server: wrong tag pattern (was @trpc/server@, actual tags use v)
- prettier: wrong tag pattern (was v{version}, actual tags have no prefix)
- react: convert to unversioned (react.dev has no version tags)
- rxjs: wrong tag pattern and docs_path
- winston: wrong tag pattern, split into two version ranges
- ioredis: remove invalid docs_path (docs/ contains generated HTML)
- knex: remove invalid docs_path (no docs/ directory at tagged version)
- kysely: fix docs_path from docs to site/docs
- turbo: fix docs_path from docs to apps/docs/content

Also fix scoped package filename bug in build.ts where / in names like
@trpc/server created invalid nested file paths.

https://claude.ai/code/session_018hhSNwmXCP2f5X6SAUqZtR