### PR TITLE
Add registry CLI command to package scripts

### DIFF
--- a/packages/registry/package.json
+++ b/packages/registry/package.json
@@ -17,6 +17,7 @@
     "build": "rimraf --glob dist/** && tsc -p tsconfig.build.json",
     "test": "vitest run",
     "test:watch": "vitest",
+    "registry": "tsx src/cli.ts",
     "test-registry": "tsx src/test-registry.ts",
     "lint": "npx biome ci --error-on-warnings",
     "fix": "npx biome check --write"


### PR DESCRIPTION
## Summary
Added a new npm script to make it easier to run the registry CLI tool during development.

## Changes
- Added `"registry": "tsx src/cli.ts"` script to `packages/registry/package.json`
  - Allows running the CLI via `npm run registry` instead of manually invoking `tsx src/cli.ts`
  - Follows the same pattern as the existing `test-registry` script

## Details
This convenience script enables developers to quickly execute the registry CLI without needing to remember or type the full command path. The script uses `tsx` for TypeScript execution, consistent with other development scripts in the package.

https://claude.ai/code/session_01AaEyJuFLLX7wWfU49KNQ3D