### PR TITLE
Trim environment variables and add auth header to package check

### DIFF
--- a/packages/registry/src/publish.ts
+++ b/packages/registry/src/publish.ts
@@ -11,11 +11,11 @@ import { readFileSync } from "node:fs";
 const DEFAULT_SERVER_URL = "https://api.context.neuledge.com";
 
 function getServerUrl(): string {
-  return process.env.REGISTRY_SERVER_URL || DEFAULT_SERVER_URL;
+  return process.env.REGISTRY_SERVER_URL?.trim() || DEFAULT_SERVER_URL;
 }
 
 function getPublishKey(): string {
-  const key = process.env.REGISTRY_PUBLISH_KEY;
+  const key = process.env.REGISTRY_PUBLISH_KEY?.trim();
   if (!key) {
     throw new Error(
       "REGISTRY_PUBLISH_KEY environment variable is required for publishing",
@@ -41,7 +41,14 @@ export async function checkPackageExists(
   version: string,
 ): Promise<PackageMetadata | null> {
   const url = `${getServerUrl()}/packages/${encodeURIComponent(registry)}/${encodeURIComponent(name)}/${encodeURIComponent(version)}`;
-  const response = await fetch(url);
+
+  const headers: Record<string, string> = {};
+  const key = process.env.REGISTRY_PUBLISH_KEY?.trim();
+  if (key) {
+    headers.Authorization = `Bearer ${key}`;
+  }
+
+  const response = await fetch(url, { headers });
 
   if (response.status === 404) {
     return null;


### PR DESCRIPTION
## Summary
This change improves the robustness of environment variable handling in the registry publish module by trimming whitespace and adds authentication support to package existence checks.

## Key Changes
- **Environment variable trimming**: Added `.trim()` calls to `REGISTRY_SERVER_URL` and `REGISTRY_PUBLISH_KEY` to handle values with accidental leading/trailing whitespace
- **Authentication for package checks**: Modified `checkPackageExists()` to include an `Authorization` header with the publish key when available, enabling authenticated requests to the registry API
- **Conditional header inclusion**: The authorization header is only added if the `REGISTRY_PUBLISH_KEY` environment variable is set, maintaining backward compatibility with unauthenticated requests

## Implementation Details
- The trimming is applied at the point of use rather than during environment variable reading, ensuring consistent behavior across all functions that access these variables
- The authorization header uses Bearer token format: `Authorization: Bearer ${key}`
- The fetch call now passes a headers object to support future header additions

https://claude.ai/code/session_011dNHeVJ7CyeYkP2iLHr83E