### PR TITLE
Add HTTP server transport support for multi-client MCP connections

### DIFF
--- a/.changeset/http-server-transport.md
+++ b/.changeset/http-server-transport.md
@@ -1,0 +1,5 @@
+---
+"@neuledge/context": minor
+---
+
+Add HTTP server transport support via `context serve --http`, enabling multiple clients on the network to connect to a single MCP server instance using the Streamable HTTP protocol

--- a/packages/context/README.md
+++ b/packages/context/README.md
@@ -409,8 +409,21 @@ context remove nextjs
 Start the MCP server (used by AI agents).
 
 ```bash
+# Stdio transport (default, for single-client MCP integrations)
 context serve
+
+# HTTP transport (for multi-client access over the network)
+context serve --http
+context serve --http 3000
+context serve --http 3000 --host 0.0.0.0
 ```
+
+| Option | Description |
+|--------|-------------|
+| `--http [port]` | Start as HTTP server instead of stdio (default port: 8080) |
+| `--host <host>` | Host to bind to (default: 127.0.0.1) |
+
+The HTTP transport uses the [MCP Streamable HTTP](https://modelcontextprotocol.io/specification/2025-03-26/basic/transports#streamable-http) protocol, enabling multiple clients on the local network to connect to a single server instance. The endpoint is available at `http://<host>:<port>/mcp`.
 
 ### `context query <library> <topic>`
 

--- a/packages/context/src/cli.ts
+++ b/packages/context/src/cli.ts
@@ -688,7 +688,12 @@ program
 program
   .command("serve")
   .description("Start the MCP server")
-  .action(async () => {
+  .option(
+    "--http [port]",
+    "Start as HTTP server instead of stdio (default port: 8080)",
+  )
+  .option("--host <host>", "Host to bind to (default: 127.0.0.1)")
+  .action(async (options: { http?: string | true; host?: string }) => {
     const store = new PackageStore();
     loadPackages(store);
 
@@ -703,7 +708,19 @@ program
     }
 
     const server = new ContextServer(store);
-    await server.start();
+
+    if (options.http !== undefined) {
+      const port =
+        typeof options.http === "string"
+          ? Number.parseInt(options.http, 10)
+          : 8080;
+      const host = options.host ?? "127.0.0.1";
+
+      const { port: actualPort } = await server.startHTTP({ port, host });
+      console.error(`Listening on http://${host}:${actualPort}/mcp`);
+    } else {
+      await server.start();
+    }
   });
 
 function formatLibraryName(pkg: PackageInfo): string {

--- a/packages/context/src/server.test.ts
+++ b/packages/context/src/server.test.ts
@@ -1,6 +1,9 @@
 import { existsSync, mkdirSync, rmSync } from "node:fs";
+import type { Server } from "node:http";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
+import { Client } from "@modelcontextprotocol/sdk/client/index.js";
+import { StreamableHTTPClientTransport } from "@modelcontextprotocol/sdk/client/streamableHttp.js";
 import type Database from "better-sqlite3";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import { search } from "./search.js";
@@ -145,5 +148,125 @@ describe("ContextServer integration", () => {
     // Verify store has the package
     expect(store.list()).toHaveLength(1);
     expect(store.list()[0]?.name).toBe("nextjs");
+  });
+});
+
+describe("ContextServer HTTP transport", () => {
+  let testDir: string;
+  let httpServer: Server;
+  let port: number;
+  const clients: Client[] = [];
+
+  beforeEach(async () => {
+    testDir = join(
+      tmpdir(),
+      `context-http-test-${Date.now()}-${Math.random().toString(36).slice(2)}`,
+    );
+    mkdirSync(testDir, { recursive: true });
+    const testPackagePath = join(testDir, "nextjs@15.0.db");
+
+    const db = createTestDb(testPackagePath, {
+      name: "nextjs",
+      version: "15.0",
+      description: "Next.js documentation",
+    });
+
+    insertChunk(db, {
+      docPath: "docs/routing/middleware.md",
+      docTitle: "Middleware",
+      sectionTitle: "Introduction",
+      content:
+        "Middleware allows you to run code before a request is completed.",
+      tokens: 20,
+    });
+    rebuildFtsIndex(db);
+    db.close();
+
+    const store = new PackageStore();
+    const info = readPackageInfo(testPackagePath);
+    store.add(info);
+
+    const ctx = new ContextServer(store);
+    const result = await ctx.startHTTP({ port: 0 });
+    httpServer = result.server;
+    port = result.port;
+  });
+
+  afterEach(async () => {
+    // Close all clients first to release SSE streams
+    await Promise.all(clients.map((c) => c.close().catch(() => {})));
+    clients.length = 0;
+
+    await new Promise<void>((resolve) => httpServer.close(() => resolve()));
+    if (existsSync(testDir)) {
+      rmSync(testDir, { recursive: true });
+    }
+  });
+
+  it("starts HTTP server and accepts MCP client connections", async () => {
+    const client = new Client({ name: "test-client", version: "1.0.0" });
+    clients.push(client);
+    const transport = new StreamableHTTPClientTransport(
+      new URL(`http://127.0.0.1:${port}/mcp`),
+    );
+
+    await client.connect(transport);
+
+    const tools = await client.listTools();
+    const toolNames = tools.tools.map((t) => t.name);
+    expect(toolNames).toContain("get_docs");
+    expect(toolNames).toContain("search_packages");
+    expect(toolNames).toContain("download_package");
+  });
+
+  it("supports multiple concurrent client sessions", async () => {
+    const client1 = new Client({ name: "client-1", version: "1.0.0" });
+    const client2 = new Client({ name: "client-2", version: "1.0.0" });
+    clients.push(client1, client2);
+
+    const transport1 = new StreamableHTTPClientTransport(
+      new URL(`http://127.0.0.1:${port}/mcp`),
+    );
+    const transport2 = new StreamableHTTPClientTransport(
+      new URL(`http://127.0.0.1:${port}/mcp`),
+    );
+
+    await client1.connect(transport1);
+    await client2.connect(transport2);
+
+    // Both clients can list tools independently
+    const [tools1, tools2] = await Promise.all([
+      client1.listTools(),
+      client2.listTools(),
+    ]);
+
+    expect(tools1.tools.map((t) => t.name)).toContain("get_docs");
+    expect(tools2.tools.map((t) => t.name)).toContain("get_docs");
+  });
+
+  it("returns tool results via HTTP transport", async () => {
+    const client = new Client({ name: "test-client", version: "1.0.0" });
+    clients.push(client);
+    const transport = new StreamableHTTPClientTransport(
+      new URL(`http://127.0.0.1:${port}/mcp`),
+    );
+
+    await client.connect(transport);
+
+    const result = await client.callTool({
+      name: "get_docs",
+      arguments: { library: "nextjs@15.0", topic: "middleware" },
+    });
+
+    const text = (result.content as { type: string; text: string }[])[0]?.text;
+    expect(text).toBeDefined();
+    const parsed = JSON.parse(text ?? "");
+    expect(parsed.library).toBe("nextjs@15.0");
+    expect(parsed.results.length).toBeGreaterThan(0);
+  });
+
+  it("returns 404 for non-MCP paths", async () => {
+    const response = await fetch(`http://127.0.0.1:${port}/other`);
+    expect(response.status).toBe(404);
   });
 });

--- a/packages/context/src/server.ts
+++ b/packages/context/src/server.ts
@@ -1,6 +1,8 @@
+import { createServer } from "node:http";
 import { createRequire } from "node:module";
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
+import { StreamableHTTPServerTransport } from "@modelcontextprotocol/sdk/server/streamableHttp.js";
 import { z } from "zod";
 import { getServerUrl } from "./config.js";
 import { downloadPackage, searchPackages } from "./download.js";
@@ -29,19 +31,113 @@ export class ContextServer {
   }
 
   /**
-   * Start the server with stdio transport.
-   * Registers tools and connects.
+   * Register all MCP tools. Called before connecting a transport.
    */
-  async start(): Promise<void> {
+  private registerTools(): void {
     const packages = this.store.list();
     if (packages.length > 0) {
       this.registerGetDocsTool(packages);
     }
     this.registerSearchPackagesTool();
     this.registerDownloadPackageTool();
+  }
+
+  /**
+   * Start the server with stdio transport.
+   * Registers tools and connects.
+   */
+  async start(): Promise<void> {
+    this.registerTools();
 
     const transport = new StdioServerTransport();
     await this.mcp.connect(transport);
+  }
+
+  /**
+   * Start the server with Streamable HTTP transport.
+   * Creates an HTTP server that handles MCP protocol over HTTP,
+   * allowing multiple clients on the network to connect.
+   *
+   * @returns The HTTP server instance and the port it's listening on.
+   */
+  async startHTTP(options: {
+    port: number;
+    host?: string;
+  }): Promise<{ server: ReturnType<typeof createServer>; port: number }> {
+    this.registerTools();
+
+    const host = options.host ?? "127.0.0.1";
+
+    // Track transports by session ID for multi-client support
+    const transports = new Map<string, StreamableHTTPServerTransport>();
+
+    const httpServer = createServer(async (req, res) => {
+      const url = new URL(req.url ?? "/", `http://${req.headers.host}`);
+
+      if (url.pathname !== "/mcp") {
+        res.writeHead(404).end("Not Found");
+        return;
+      }
+
+      // Handle DELETE for session termination
+      if (req.method === "DELETE") {
+        const sessionId = req.headers["mcp-session-id"] as string | undefined;
+        const transport = sessionId ? transports.get(sessionId) : undefined;
+        if (sessionId && transport) {
+          await transport.close();
+          transports.delete(sessionId);
+          res.writeHead(200).end();
+        } else {
+          res.writeHead(404).end("Session not found");
+        }
+        return;
+      }
+
+      // For GET and POST, route to existing transport or create new one
+      const sessionId = req.headers["mcp-session-id"] as string | undefined;
+
+      if (sessionId && transports.has(sessionId)) {
+        // Existing session
+        await transports.get(sessionId)?.handleRequest(req, res);
+        return;
+      }
+
+      if (sessionId && !transports.has(sessionId)) {
+        // Invalid session ID
+        res.writeHead(404).end("Session not found");
+        return;
+      }
+
+      // New session (no session ID header) — create a new transport.
+      // Pre-generate the session ID so we can store the transport before
+      // handleRequest (which may keep an SSE stream open indefinitely).
+      const newSessionId = crypto.randomUUID();
+      const transport = new StreamableHTTPServerTransport({
+        sessionIdGenerator: () => newSessionId,
+      });
+
+      transport.onclose = () => {
+        transports.delete(newSessionId);
+      };
+
+      transports.set(newSessionId, transport);
+
+      // Each new transport gets its own ContextServer sharing the same store
+      const sessionCtx = new ContextServer(this.store);
+      sessionCtx.registerTools();
+
+      await sessionCtx.mcp.connect(transport);
+      await transport.handleRequest(req, res);
+    });
+
+    return new Promise((resolve) => {
+      httpServer.listen(options.port, host, () => {
+        const addr = httpServer.address();
+        const actualPort =
+          typeof addr === "object" && addr ? addr.port : options.port;
+        resolve({ server: httpServer, port: actualPort });
+      });
+    });
   }
 
   /** Access the underlying McpServer for testing. */


### PR DESCRIPTION
## Summary
This PR adds HTTP server transport support to the ContextServer, enabling multiple clients on the network to connect to a single MCP server instance using the Streamable HTTP protocol. Previously, the server only supported stdio transport for single-client integrations.

## Key Changes

- **New `startHTTP()` method**: Implements HTTP server transport with support for multiple concurrent client sessions. Each client gets its own transport instance while sharing the same package store.

- **Session management**: Implements session tracking via `mcp-session-id` headers, allowing clients to maintain persistent connections. Sessions can be terminated via DELETE requests.

- **CLI enhancements**: Added `--http [port]` and `--host <host>` options to the `serve` command, with sensible defaults (port 8080, host 127.0.0.1).

- **Tool registration refactoring**: Extracted tool registration into a private `registerTools()` method to avoid duplication between stdio and HTTP transports.

- **Comprehensive test coverage**: Added integration tests covering:
  - Basic HTTP server startup and client connections
  - Multiple concurrent client sessions
  - Tool invocation via HTTP transport
  - 404 handling for non-MCP paths

- **Documentation**: Updated README with HTTP transport usage examples and configuration options.

## Implementation Details

- The HTTP server routes all requests to `/mcp` endpoint; other paths return 404
- New sessions are created on-demand when clients connect without a session ID
- Each session gets a unique UUID and maintains its own `StreamableHTTPServerTransport` instance
- Sessions are automatically cleaned up when transports close
- The implementation uses Node.js built-in `http` module and MCP SDK's `StreamableHTTPServerTransport`

https://claude.ai/code/session_01Stxaw8C1ozXKjJSuP3v1Sp