### PR TITLE
Add Docker deployment documentation to README

### DIFF
--- a/packages/context/README.md
+++ b/packages/context/README.md
@@ -255,6 +255,19 @@ context add ./packages/my-lib@2.0.db
 
 ---
 
+## :whale: Docker
+
+Run Context as a containerized HTTP server for multi-client or Kubernetes deployments:
+
+```bash
+docker build -t context:local .
+docker run --rm -p 8080:8080 context:local
+```
+
+The container starts Context with HTTP transport on port 8080, accessible at `http://localhost:8080/mcp`. The image uses a multi-stage build with `node:22-bookworm-slim` for native module compatibility.
+
+---
+
 ## :books: CLI Reference
 
 ### `context browse <package>`


### PR DESCRIPTION
## Summary
Added Docker deployment instructions to the Context README to document how to run Context as a containerized HTTP server for multi-client and Kubernetes deployments.

## Changes
- Added new "Docker" section in the README with:
  - Docker build and run commands for containerizing Context
  - Instructions for accessing the HTTP server on port 8080 at `http://localhost:8080/mcp`
  - Technical details about the multi-stage build using `node:22-bookworm-slim` for native module compatibility

## Details
The documentation provides users with a straightforward way to deploy Context in containerized environments, making it easier to integrate with orchestration platforms like Kubernetes or use in multi-client scenarios where HTTP transport is preferred over direct CLI usage.

https://claude.ai/code/session_013d4ceoxhaKc16SEm3oFcew