### PR TITLE
Add explicit permissions to CI/CD workflows for secure PR operations

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,6 +14,10 @@ on:
       - '.*/*.md'
       - '.*/**/*.md'
 
+permissions:
+  contents: read
+  pull-requests: write
+
 jobs:
   lint:
     name: Lint

--- a/.github/workflows/registry-update.yml
+++ b/.github/workflows/registry-update.yml
@@ -15,6 +15,8 @@ on:
         required: false
         type: string
 
+permissions: {}
+
 jobs:
   publish:
     name: Build & Publish Packages

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,6 +5,8 @@ on:
     branches:
       - main
 
+permissions: {}
+
 concurrency: ${{ github.workflow }}-${{ github.ref }}
 
 jobs:


### PR DESCRIPTION
CI workflow gets contents:read + pull-requests:write for PR check statuses.
Release and registry-update workflows get top-level permissions:{} to drop
all defaults, relying on job-level grants only where needed. No secrets are
exposed to the CI workflow.

https://claude.ai/code/session_0186KJ6vpzLNLYbCbFhDUxb9