### PR TITLE
Fix documentation source URLs and tag patterns for multiple packages

### DIFF
--- a/registry/npm/@tanstack/react-router.yaml
+++ b/registry/npm/@tanstack/react-router.yaml
@@ -8,4 +8,4 @@ versions:
       type: git
       url: https://github.com/TanStack/router
       docs_path: docs
-    tag_pattern: "v{version}"
+    tag_pattern: "@tanstack/react-router@{version}"

--- a/registry/npm/kysely.yaml
+++ b/registry/npm/kysely.yaml
@@ -3,7 +3,14 @@ description: "Type-safe TypeScript SQL query builder"
 repository: https://github.com/kysely-org/kysely
 
 versions:
+  - min_version: "0.28.3"
+    source:
+      type: git
+      url: https://github.com/kysely-org/kysely
+      docs_path: site/docs
+    tag_pattern: "v{version}"
   - min_version: "0.26.0"
+    max_version: "0.28.3"
     source:
       type: git
       url: https://github.com/kysely-org/kysely

--- a/registry/npm/nx.yaml
+++ b/registry/npm/nx.yaml
@@ -8,4 +8,4 @@ versions:
       type: git
       url: https://github.com/nrwl/nx
       docs_path: docs
-    tag_pattern: "v{version}"
+    tag_pattern: "{version}"

--- a/registry/python/python.yaml
+++ b/registry/python/python.yaml
@@ -3,10 +3,21 @@ description: "Python programming language official documentation"
 repository: https://github.com/python/cpython
 
 versions:
-  - versions: ["3.14", "3.13", "3.12"]
+  - versions: ["3.14"]
     source:
       type: zip
       url: "https://docs.python.org/3/archives/python-{version}-docs-html.zip"
+      docs_path: "python-{version}-docs-html"
+      exclude_paths:
+        - "whatsnew/**"
+        - "changelog.html"
+        - "deprecations/**"
+        - "installing/**"
+        - "distributing/**"
+  - versions: ["3.13", "3.12"]
+    source:
+      type: zip
+      url: "https://docs.python.org/{version}/archives/python-{version}-docs-html.zip"
       docs_path: "python-{version}-docs-html"
       exclude_paths:
         - "whatsnew/**"


### PR DESCRIPTION
## Summary
This PR updates documentation registry configurations for Python, Kysely, TanStack React Router, and Nx packages to fix source URLs and tag patterns for proper documentation retrieval.

## Key Changes

- **Python**: Split version configurations to use different documentation URLs
  - Python 3.14 continues using the `/3/archives/` path
  - Python 3.12 and 3.13 now use the versioned path `/3.{version}/archives/`

- **Kysely**: Added version range constraints and new documentation source
  - Added new entry for versions >= 0.28.3 with git-based documentation source
  - Added `max_version: "0.28.3"` constraint to existing 0.26.0+ entry to prevent overlap

- **TanStack React Router**: Updated tag pattern
  - Changed from `v{version}` to `@tanstack/react-router@{version}` to match actual git tags

- **Nx**: Updated tag pattern
  - Changed from `v{version}` to `{version}` to match actual git tags

## Implementation Details
These changes ensure that documentation sources are correctly resolved by using the appropriate URLs and git tag patterns that match the actual repository structure and tagging conventions for each package.

https://claude.ai/code/session_0148oR3Ar3vPbMh5hiLNwXpd