### PR TITLE
feat: support arbitrary URL ingestion (blog posts, articles, docs)

### DIFF
--- a/.changeset/curious-fox-789.md
+++ b/.changeset/curious-fox-789.md
@@ -1,0 +1,12 @@
+---
+"@neuledge/context": minor
+---
+
+Add support for ingesting arbitrary URLs when `llms.txt` is not found
+
+- `context add <url>` now falls back to fetching the page directly if `llms.txt` is unavailable, enabling ingestion of blog posts, articles, documentation pages, and raw markdown files
+- Added `suggestPackageNameFromUrl()` to derive meaningful package names from URL paths
+- Added `fetchWebPage()` helper with content-type detection and binary rejection
+- All HTTP fetches now include browser-like headers to bypass basic bot protection
+- Added per-platform authentication via `context auth add/list/remove` for accessing subscriber-only content with cookies
+- Auth is stored in `~/.context/auth.json` and matched by domain (with parent-domain fallback for subdomains)

--- a/packages/context/src/auth.test.ts
+++ b/packages/context/src/auth.test.ts
@@ -44,6 +44,23 @@ describe("findAuthForUrl", () => {
   it("returns null for invalid URLs", () => {
     expect(findAuthForUrl({}, "not-a-url")).toBeNull();
   });
+
+  it("stops after one parent domain to avoid overly broad matches", () => {
+    // a.b.example.com should match b.example.com (one parent) but not example.com
+    const auth: AuthConfig = {
+      "b.example.com": { cookies: "specific" },
+      "example.com": { cookies: "too-generic" },
+    };
+    expect(findAuthForUrl(auth, "https://a.b.example.com/page")).toEqual({
+      cookies: "specific",
+    });
+
+    // c.d.example.com should NOT match example.com (two parents away)
+    const auth2: AuthConfig = {
+      "example.com": { cookies: "too-generic" },
+    };
+    expect(findAuthForUrl(auth2, "https://c.d.example.com/page")).toBeNull();
+  });
 });
 
 describe("withPlatformAuth", () => {

--- a/packages/context/src/auth.test.ts
+++ b/packages/context/src/auth.test.ts
@@ -1,0 +1,87 @@
+import { describe, expect, it } from "vitest";
+import { type AuthConfig, findAuthForUrl, withPlatformAuth } from "./auth.js";
+
+describe("findAuthForUrl", () => {
+  it("matches exact hostname", () => {
+    const auth: AuthConfig = {
+      "medium.com": { cookies: "uid=abc" },
+    };
+    expect(findAuthForUrl(auth, "https://medium.com/article")).toEqual({
+      cookies: "uid=abc",
+    });
+  });
+
+  it("matches parent domain for subdomains", () => {
+    const auth: AuthConfig = {
+      "substack.com": { cookies: "sid=xyz" },
+    };
+    expect(
+      findAuthForUrl(auth, "https://rafahari.substack.com/p/post"),
+    ).toEqual({
+      cookies: "sid=xyz",
+    });
+  });
+
+  it("prefers more specific domain over parent", () => {
+    const auth: AuthConfig = {
+      "substack.com": { cookies: "generic" },
+      "rafahari.substack.com": { cookies: "specific" },
+    };
+    expect(
+      findAuthForUrl(auth, "https://rafahari.substack.com/p/post"),
+    ).toEqual({
+      cookies: "specific",
+    });
+  });
+
+  it("returns null when no match", () => {
+    const auth: AuthConfig = {
+      "medium.com": { cookies: "uid=abc" },
+    };
+    expect(findAuthForUrl(auth, "https://example.com")).toBeNull();
+  });
+
+  it("returns null for invalid URLs", () => {
+    expect(findAuthForUrl({}, "not-a-url")).toBeNull();
+  });
+});
+
+describe("withPlatformAuth", () => {
+  it("returns base headers when no auth match", () => {
+    const result = withPlatformAuth({}, "https://example.com", {
+      "User-Agent": "test",
+    });
+    expect(result.headers).toEqual({ "User-Agent": "test" });
+    expect(result.redirect).toBe("follow");
+  });
+
+  it("merges cookies from matched auth", () => {
+    const auth: AuthConfig = {
+      "medium.com": { cookies: "uid=abc" },
+    };
+    const result = withPlatformAuth(auth, "https://medium.com/article", {
+      "User-Agent": "test",
+    });
+    expect(result.headers).toEqual({
+      "User-Agent": "test",
+      Cookie: "uid=abc",
+    });
+  });
+
+  it("merges extra headers from matched auth", () => {
+    const auth: AuthConfig = {
+      "medium.com": {
+        cookies: "uid=abc",
+        headers: { "x-frontend": "true" },
+      },
+    };
+    const result = withPlatformAuth(auth, "https://medium.com/article", {
+      "User-Agent": "test",
+    });
+    expect(result.headers).toEqual({
+      "User-Agent": "test",
+      Cookie: "uid=abc",
+      "x-frontend": "true",
+    });
+  });
+});

--- a/packages/context/src/auth.ts
+++ b/packages/context/src/auth.ts
@@ -7,7 +7,13 @@
  * content automatically.
  */
 
-import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import {
+  chmodSync,
+  existsSync,
+  mkdirSync,
+  readFileSync,
+  writeFileSync,
+} from "node:fs";
 import { homedir } from "node:os";
 import { join } from "node:path";
 
@@ -22,24 +28,36 @@ export type AuthConfig = Record<string, PlatformAuth>;
 
 const AUTH_PATH = join(homedir(), ".context", "auth.json");
 
+let authCache: AuthConfig | undefined;
+
+/** Clear the in-memory auth cache. Useful in tests. */
+export function clearAuthCache(): void {
+  authCache = undefined;
+}
+
 /** Load auth config from disk. Returns empty object if missing. */
 export function loadAuth(): AuthConfig {
+  if (authCache !== undefined) return authCache;
   try {
     if (existsSync(AUTH_PATH)) {
       const raw = readFileSync(AUTH_PATH, "utf-8");
-      return JSON.parse(raw) as AuthConfig;
+      authCache = JSON.parse(raw) as AuthConfig;
+      return authCache;
     }
   } catch {
     // Ignore parse errors — treat as empty
   }
-  return {};
+  authCache = {};
+  return authCache;
 }
 
 /** Save auth config to disk. */
 export function saveAuth(auth: AuthConfig): void {
   const dir = join(homedir(), ".context");
   mkdirSync(dir, { recursive: true });
-  writeFileSync(AUTH_PATH, JSON.stringify(auth, null, 2), "utf-8");
+  chmodSync(dir, 0o700);
+  writeFileSync(AUTH_PATH, JSON.stringify(auth, null, 2), { mode: 0o600 });
+  authCache = auth;
 }
 
 /**
@@ -59,9 +77,11 @@ export function findAuthForUrl(
     return null;
   }
 
-  // Try exact match, then parent domains
+  // Try exact match, then one immediate parent domain only.
+  // We intentionally stop after one parent to avoid matching public
+  // suffixes like co.uk.
   const parts = hostname.split(".");
-  for (let i = 0; i < parts.length - 1; i++) {
+  for (let i = 0; i < Math.min(2, parts.length - 1); i++) {
     const domain = parts.slice(i).join(".");
     if (auth[domain]) {
       return auth[domain];

--- a/packages/context/src/auth.ts
+++ b/packages/context/src/auth.ts
@@ -1,0 +1,99 @@
+/**
+ * Per-platform authentication configuration.
+ *
+ * Many content platforms (Medium, Substack, etc.) gate content behind
+ * login. Users with legitimate subscriptions can store cookies/auth
+ * tokens per domain so that `context add <url>` can fetch authenticated
+ * content automatically.
+ */
+
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { homedir } from "node:os";
+import { join } from "node:path";
+
+export interface PlatformAuth {
+  /** Cookie string sent as the Cookie header. */
+  cookies?: string;
+  /** Additional headers to send with requests to this platform. */
+  headers?: Record<string, string>;
+}
+
+export type AuthConfig = Record<string, PlatformAuth>;
+
+const AUTH_PATH = join(homedir(), ".context", "auth.json");
+
+/** Load auth config from disk. Returns empty object if missing. */
+export function loadAuth(): AuthConfig {
+  try {
+    if (existsSync(AUTH_PATH)) {
+      const raw = readFileSync(AUTH_PATH, "utf-8");
+      return JSON.parse(raw) as AuthConfig;
+    }
+  } catch {
+    // Ignore parse errors — treat as empty
+  }
+  return {};
+}
+
+/** Save auth config to disk. */
+export function saveAuth(auth: AuthConfig): void {
+  const dir = join(homedir(), ".context");
+  mkdirSync(dir, { recursive: true });
+  writeFileSync(AUTH_PATH, JSON.stringify(auth, null, 2), "utf-8");
+}
+
+/**
+ * Find the best matching auth entry for a URL.
+ *
+ * Looks for an exact hostname match first, then tries progressively
+ * shorter parent domains (e.g., `rafahari.substack.com` → `substack.com`).
+ */
+export function findAuthForUrl(
+  auth: AuthConfig,
+  url: string,
+): PlatformAuth | null {
+  let hostname: string;
+  try {
+    hostname = new URL(url).hostname;
+  } catch {
+    return null;
+  }
+
+  // Try exact match, then parent domains
+  const parts = hostname.split(".");
+  for (let i = 0; i < parts.length - 1; i++) {
+    const domain = parts.slice(i).join(".");
+    if (auth[domain]) {
+      return auth[domain];
+    }
+  }
+
+  return null;
+}
+
+/**
+ * Build RequestInit headers for a fetch, merging platform auth
+ * if a matching entry exists.
+ */
+export function withPlatformAuth(
+  auth: AuthConfig,
+  url: string,
+  baseHeaders: Record<string, string> = {},
+): RequestInit {
+  const platformAuth = findAuthForUrl(auth, url);
+  if (!platformAuth) {
+    return { headers: baseHeaders, redirect: "follow" };
+  }
+
+  const headers: Record<string, string> = { ...baseHeaders };
+
+  if (platformAuth.cookies) {
+    headers.Cookie = platformAuth.cookies;
+  }
+
+  if (platformAuth.headers) {
+    Object.assign(headers, platformAuth.headers);
+  }
+
+  return { headers, redirect: "follow" };
+}

--- a/packages/context/src/cli.test.ts
+++ b/packages/context/src/cli.test.ts
@@ -1,9 +1,11 @@
 import { describe, expect, it } from "vitest";
 import {
   detectSourceType,
+  fetchWebPage,
   packageNameFromUrl,
   parseRegistryPackage,
   resolveLlmsTxtUrls,
+  suggestPackageNameFromUrl,
 } from "./cli.js";
 
 describe("detectSourceType", () => {
@@ -229,5 +231,122 @@ describe("packageNameFromUrl", () => {
 
   it("strips www prefix", () => {
     expect(packageNameFromUrl("https://www.prisma.io/docs")).toBe("prisma.io");
+  });
+});
+
+describe("suggestPackageNameFromUrl", () => {
+  it("returns hostname for domain roots", () => {
+    expect(suggestPackageNameFromUrl("https://overreacted.io/")).toBe(
+      "overreacted.io",
+    );
+    expect(suggestPackageNameFromUrl("https://example.com")).toBe(
+      "example.com",
+    );
+  });
+
+  it("includes sanitized path for specific pages", () => {
+    expect(
+      suggestPackageNameFromUrl(
+        "https://overreacted.io/things-i-dont-know-as-of-2018/",
+      ),
+    ).toBe("overreacted.io-things-i-dont-know-as-of-2018");
+    expect(
+      suggestPackageNameFromUrl("https://example.com/blog/my-first-post"),
+    ).toBe("example.com-blog-my-first-post");
+  });
+
+  it("strips www prefix", () => {
+    expect(
+      suggestPackageNameFromUrl("https://www.example.com/article/hello-world"),
+    ).toBe("example.com-article-hello-world");
+  });
+
+  it("handles paths with special characters", () => {
+    expect(suggestPackageNameFromUrl("https://site.com/a_b.c/d+e")).toBe(
+      "site.com-a-b-c-d-e",
+    );
+  });
+});
+
+describe("fetchWebPage", () => {
+  function makeFetch(
+    responses: Record<
+      string,
+      { body: string; status?: number; contentType?: string }
+    >,
+  ): typeof fetch {
+    return (async (input: string | URL | Request) => {
+      const url = typeof input === "string" ? input : input.toString();
+      const r = responses[url];
+      if (!r) {
+        return new Response("not found", { status: 404 });
+      }
+      return new Response(r.body, {
+        status: r.status ?? 200,
+        headers: { "content-type": r.contentType ?? "text/markdown" },
+      });
+    }) as typeof fetch;
+  }
+
+  it("returns content and isHtml=false for markdown", async () => {
+    const fetchImpl = makeFetch({
+      "https://example.com/post": {
+        body: "# Hello\n\nWorld",
+        contentType: "text/markdown",
+      },
+    });
+    const page = await fetchWebPage("https://example.com/post", fetchImpl);
+    expect(page).not.toBeNull();
+    expect(page?.content).toBe("# Hello\n\nWorld");
+    expect(page?.isHtml).toBe(false);
+  });
+
+  it("returns isHtml=true for HTML responses", async () => {
+    const fetchImpl = makeFetch({
+      "https://example.com/page": {
+        body: "<html><body><h1>Hi</h1></body></html>",
+        contentType: "text/html; charset=utf-8",
+      },
+    });
+    const page = await fetchWebPage("https://example.com/page", fetchImpl);
+    expect(page?.isHtml).toBe(true);
+  });
+
+  it("sniffs HTML when content-type is missing", async () => {
+    const fetchImpl = makeFetch({
+      "https://example.com/page": {
+        body: "<html><body>Hi</body></html>",
+        contentType: "",
+      },
+    });
+    const page = await fetchWebPage("https://example.com/page", fetchImpl);
+    expect(page?.isHtml).toBe(true);
+  });
+
+  it("returns null for PDF content", async () => {
+    const fetchImpl = makeFetch({
+      "https://example.com/paper.pdf": {
+        body: "%PDF-1.4...",
+        contentType: "application/pdf",
+      },
+    });
+    const page = await fetchWebPage("https://example.com/paper.pdf", fetchImpl);
+    expect(page).toBeNull();
+  });
+
+  it("returns null for failed requests", async () => {
+    const fetchImpl = makeFetch({
+      "https://example.com/bad": { body: "error", status: 500 },
+    });
+    const page = await fetchWebPage("https://example.com/bad", fetchImpl);
+    expect(page).toBeNull();
+  });
+
+  it("returns null for empty responses", async () => {
+    const fetchImpl = makeFetch({
+      "https://example.com/empty": { body: "   " },
+    });
+    const page = await fetchWebPage("https://example.com/empty", fetchImpl);
+    expect(page).toBeNull();
   });
 });

--- a/packages/context/src/cli.test.ts
+++ b/packages/context/src/cli.test.ts
@@ -349,4 +349,38 @@ describe("fetchWebPage", () => {
     const page = await fetchWebPage("https://example.com/empty", fetchImpl);
     expect(page).toBeNull();
   });
+
+  it("returns null when content-length exceeds 10 MB", async () => {
+    const fetchImpl = (async () => {
+      return new Response("<html>big</html>", {
+        status: 200,
+        headers: {
+          "content-type": "text/html",
+          "content-length": "20971520",
+        },
+      });
+    }) as typeof fetch;
+    const page = await fetchWebPage(
+      "https://example.com/huge",
+      fetchImpl,
+      1000,
+    );
+    expect(page).toBeNull();
+  });
+
+  it("returns null on timeout", async () => {
+    const fetchImpl = (async (_input, init) => {
+      return new Promise<Response>((_, reject) => {
+        if (init?.signal?.aborted) {
+          reject(new DOMException("Aborted", "AbortError"));
+          return;
+        }
+        init?.signal?.addEventListener("abort", () => {
+          reject(new DOMException("Aborted", "AbortError"));
+        });
+      });
+    }) as typeof fetch;
+    const page = await fetchWebPage("https://example.com/slow", fetchImpl, 100);
+    expect(page).toBeNull();
+  });
 });

--- a/packages/context/src/cli.ts
+++ b/packages/context/src/cli.ts
@@ -19,6 +19,7 @@ import { Command } from "commander";
 const require = createRequire(import.meta.url);
 const { version } = require("../package.json") as { version: string };
 
+import { loadAuth, saveAuth, withPlatformAuth } from "./auth.js";
 import { getServerUrl } from "./config.js";
 import { initDatabase } from "./database.js";
 import { downloadPackage, searchPackages } from "./download.js";
@@ -140,6 +141,106 @@ export function packageNameFromUrl(url: string): string {
 }
 
 /**
+ * Derive a package name from an arbitrary URL, including path.
+ * e.g., "https://overreacted.io/things-i-dont-know-as-of-2018/" → "overreacted.io-things-i-dont-know-as-of-2018"
+ */
+export function suggestPackageNameFromUrl(url: string): string {
+  const parsed = new URL(url);
+  const host = parsed.hostname.replace(/^www\./, "");
+  const path = parsed.pathname.replace(/\/$/, "").replace(/^\//, "");
+  if (!path) return host;
+  const sanitizedPath = path
+    .toLowerCase()
+    .replace(/[^a-z0-9-]/g, "-")
+    .replace(/-+/g, "-")
+    .replace(/^-|-$/g, "");
+  return sanitizedPath ? `${host}-${sanitizedPath}` : host;
+}
+
+/** Default browser-like headers to bypass basic bot protection. */
+export const DEFAULT_FETCH_HEADERS: Record<string, string> = {
+  "User-Agent":
+    "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/135.0.0.0 Safari/537.36",
+  Accept:
+    "text/html,application/xhtml+xml,application/xml;q=0.9,image/avif,image/webp,*/*;q=0.8",
+  "Accept-Language": "en-US,en;q=0.5",
+  "Accept-Encoding": "gzip, deflate, br",
+  DNT: "1",
+  Connection: "keep-alive",
+  "Upgrade-Insecure-Requests": "1",
+  "Sec-Fetch-Dest": "document",
+  "Sec-Fetch-Mode": "navigate",
+  "Sec-Fetch-Site": "none",
+  "Sec-Fetch-User": "?1",
+};
+
+/** Build fetch init options, merging platform auth and optional cookies from env. */
+export function buildFetchOptions(
+  url?: string,
+  extraHeaders?: Record<string, string>,
+): RequestInit {
+  const baseHeaders = { ...DEFAULT_FETCH_HEADERS, ...extraHeaders };
+
+  // Platform-aware auth (per-domain cookies/headers)
+  if (url) {
+    const auth = loadAuth();
+    return withPlatformAuth(auth, url, baseHeaders);
+  }
+
+  // Fallback to env-based cookies for backwards compatibility
+  const cookieEnv = process.env.CONTEXT_FETCH_COOKIES;
+  if (cookieEnv) {
+    baseHeaders.Cookie = cookieEnv;
+  }
+
+  return { headers: baseHeaders, redirect: "follow" };
+}
+
+export interface FetchedWebPage {
+  content: string;
+  isHtml: boolean;
+}
+
+/**
+ * Fetch a web page and determine if it's HTML.
+ * Returns null on failure or if the content is a known binary type.
+ */
+export async function fetchWebPage(
+  url: string,
+  fetchImpl: typeof fetch = fetch,
+): Promise<FetchedWebPage | null> {
+  try {
+    const response = await fetchImpl(url, buildFetchOptions(url));
+    if (!response.ok) return null;
+
+    const text = await response.text();
+    if (!text.trim()) return null;
+
+    const contentType =
+      response.headers.get("content-type")?.toLowerCase() ?? "";
+
+    // Reject known binary content types
+    if (
+      contentType.includes("application/pdf") ||
+      contentType.startsWith("image/") ||
+      contentType.startsWith("video/") ||
+      contentType.startsWith("audio/")
+    ) {
+      return null;
+    }
+
+    const isHtml =
+      contentType.includes("text/html") ||
+      contentType.includes("application/xhtml") ||
+      (!contentType && /<html[\s>]/i.test(text.slice(0, 1024)));
+
+    return { content: text, isHtml };
+  } catch {
+    return null;
+  }
+}
+
+/**
  * Resolve the llms.txt URL to fetch.
  * If the URL already points to a specific llms.txt file, use it directly.
  * Otherwise, try well-known paths from the site root.
@@ -172,7 +273,7 @@ async function addFromWebsite(
   for (const url of urls) {
     console.log(`Trying ${url}...`);
     try {
-      const response = await fetch(url);
+      const response = await fetch(url, buildFetchOptions(url));
       if (response.ok) {
         const text = await response.text();
         // Sanity check: must have some meaningful content
@@ -189,9 +290,59 @@ async function addFromWebsite(
   }
 
   if (!content || !resolvedUrl) {
-    throw new Error(
-      `No llms.txt found at ${source}. Tried:\n${urls.map((u) => `  - ${u}`).join("\n")}\n\nThis website may not provide an llms.txt file. See https://llmstxt.org/ for details.`,
+    // Fallback: fetch the original URL as a single page
+    console.log(`No llms.txt found. Fetching page content directly...`);
+    const page = await fetchWebPage(source);
+    if (!page) {
+      throw new Error(
+        `No llms.txt found at ${source}. Tried:\n${urls.map((u) => `  - ${u}`).join("\n")}\n\nAnd could not fetch the page directly. The site may be unavailable or use an unsupported content type.`,
+      );
+    }
+
+    const packageName = options.name ?? suggestPackageNameFromUrl(source);
+    const versionLabel = options.version ?? "latest";
+
+    const parsedUrl = new URL(source);
+    let path = parsedUrl.pathname.replace(/\/$/, "") || "/index";
+    if (!/\.(md|mdx|html?|adoc|rst|txt)$/i.test(path)) {
+      path += page.isHtml ? ".html" : ".md";
+    }
+    const docPath = parsedUrl.host + path;
+
+    const files: MarkdownFile[] = [{ path: docPath, content: page.content }];
+
+    ensureDataDir();
+    const outputPath = join(
+      DATA_DIR,
+      getPackageFileName(packageName, versionLabel),
     );
+
+    console.log(`Building package...`);
+    const result = buildPackage(outputPath, files, {
+      name: packageName,
+      version: versionLabel,
+      sourceUrl: source,
+    });
+
+    if (result.sectionCount === 0) {
+      throw new Error(
+        `No documentation sections could be extracted from ${source}. The page may be empty or in an unsupported format.`,
+      );
+    }
+
+    console.log(`✓ Built package: ${packageName}@${versionLabel}`);
+    console.log(`✓ Saved to ${outputPath}`);
+
+    if (options.save) {
+      savePackageCopy(outputPath, options.save, packageName, versionLabel);
+    }
+
+    const sizeBytes = statSync(outputPath).size;
+
+    console.log(
+      `\nInstalled: ${packageName}@${versionLabel} (${formatBytes(sizeBytes)}, ${result.sectionCount} sections)`,
+    );
+    return;
   }
 
   const packageName = options.name ?? packageNameFromUrl(source);
@@ -1103,6 +1254,97 @@ program
       }
     },
   );
+
+program
+  .command("auth")
+  .description("Manage per-platform authentication (cookies, headers)")
+  .addCommand(
+    new Command("add")
+      .description("Add or update auth for a domain")
+      .argument(
+        "<domain>",
+        "Domain to authenticate (e.g., medium.com, substack.com)",
+      )
+      .option("--cookies <cookies>", "Cookie string (e.g., 'uid=abc; sid=def')")
+      .option(
+        "--header <header>",
+        "Additional header in 'Key: Value' format (repeatable)",
+        collectHeaders,
+        {},
+      )
+      .action(
+        (
+          domain: string,
+          options: { cookies?: string; header: Record<string, string> },
+        ) => {
+          const auth = loadAuth();
+          auth[domain] = {
+            cookies: options.cookies,
+            headers:
+              Object.keys(options.header).length > 0
+                ? options.header
+                : undefined,
+          };
+          saveAuth(auth);
+          console.log(`✓ Auth saved for ${domain}`);
+        },
+      ),
+  )
+  .addCommand(
+    new Command("list")
+      .description("List configured platform auth entries")
+      .action(() => {
+        const auth = loadAuth();
+        const domains = Object.keys(auth);
+        if (domains.length === 0) {
+          console.log("No platform auth configured.");
+          console.log("Run: context auth add <domain> --cookies <cookies>");
+          return;
+        }
+        console.log("Configured platform auth:\n");
+        for (const domain of domains.sort()) {
+          const entry = auth[domain];
+          if (!entry) continue;
+          const hasCookies = entry.cookies ? "yes" : "no";
+          const headerCount = entry.headers
+            ? Object.keys(entry.headers).length
+            : 0;
+          console.log(
+            `  ${domain.padEnd(24)} cookies: ${hasCookies}  headers: ${headerCount}`,
+          );
+        }
+      }),
+  )
+  .addCommand(
+    new Command("remove")
+      .description("Remove auth for a domain")
+      .argument("<domain>", "Domain to remove auth for")
+      .action((domain: string) => {
+        const auth = loadAuth();
+        if (!auth[domain]) {
+          console.error(`Error: No auth found for ${domain}`);
+          process.exit(1);
+        }
+        delete auth[domain];
+        saveAuth(auth);
+        console.log(`✓ Removed auth for ${domain}`);
+      }),
+  );
+
+/** Collect repeated --header options into a Record. */
+function collectHeaders(
+  value: string,
+  previous: Record<string, string>,
+): Record<string, string> {
+  const sep = value.indexOf(":");
+  if (sep <= 0) {
+    throw new Error(`Invalid header format: "${value}". Use "Key: Value"."`);
+  }
+  const key = value.slice(0, sep).trim();
+  const val = value.slice(sep + 1).trim();
+  previous[key] = val;
+  return previous;
+}
 
 // Only parse when run directly (not when imported for testing)
 const isRunDirectly =

--- a/packages/context/src/cli.ts
+++ b/packages/context/src/cli.ts
@@ -19,10 +19,11 @@ import { Command } from "commander";
 const require = createRequire(import.meta.url);
 const { version } = require("../package.json") as { version: string };
 
-import { loadAuth, saveAuth, withPlatformAuth } from "./auth.js";
+import { loadAuth, saveAuth } from "./auth.js";
 import { getServerUrl } from "./config.js";
 import { initDatabase } from "./database.js";
 import { downloadPackage, searchPackages } from "./download.js";
+import { buildFetchOptions } from "./fetch.js";
 import {
   checkoutRef,
   cloneRepository,
@@ -157,45 +158,6 @@ export function suggestPackageNameFromUrl(url: string): string {
   return sanitizedPath ? `${host}-${sanitizedPath}` : host;
 }
 
-/** Default browser-like headers to bypass basic bot protection. */
-export const DEFAULT_FETCH_HEADERS: Record<string, string> = {
-  "User-Agent":
-    "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/135.0.0.0 Safari/537.36",
-  Accept:
-    "text/html,application/xhtml+xml,application/xml;q=0.9,image/avif,image/webp,*/*;q=0.8",
-  "Accept-Language": "en-US,en;q=0.5",
-  "Accept-Encoding": "gzip, deflate, br",
-  DNT: "1",
-  Connection: "keep-alive",
-  "Upgrade-Insecure-Requests": "1",
-  "Sec-Fetch-Dest": "document",
-  "Sec-Fetch-Mode": "navigate",
-  "Sec-Fetch-Site": "none",
-  "Sec-Fetch-User": "?1",
-};
-
-/** Build fetch init options, merging platform auth and optional cookies from env. */
-export function buildFetchOptions(
-  url?: string,
-  extraHeaders?: Record<string, string>,
-): RequestInit {
-  const baseHeaders = { ...DEFAULT_FETCH_HEADERS, ...extraHeaders };
-
-  // Platform-aware auth (per-domain cookies/headers)
-  if (url) {
-    const auth = loadAuth();
-    return withPlatformAuth(auth, url, baseHeaders);
-  }
-
-  // Fallback to env-based cookies for backwards compatibility
-  const cookieEnv = process.env.CONTEXT_FETCH_COOKIES;
-  if (cookieEnv) {
-    baseHeaders.Cookie = cookieEnv;
-  }
-
-  return { headers: baseHeaders, redirect: "follow" };
-}
-
 export interface FetchedWebPage {
   content: string;
   isHtml: boolean;
@@ -208,10 +170,24 @@ export interface FetchedWebPage {
 export async function fetchWebPage(
   url: string,
   fetchImpl: typeof fetch = fetch,
+  timeoutMs: number = 30_000,
 ): Promise<FetchedWebPage | null> {
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), timeoutMs);
   try {
-    const response = await fetchImpl(url, buildFetchOptions(url));
+    const response = await fetchImpl(url, {
+      ...buildFetchOptions(url),
+      signal: controller.signal,
+    });
     if (!response.ok) return null;
+
+    const contentLength = response.headers.get("content-length");
+    if (
+      contentLength &&
+      Number.parseInt(contentLength, 10) > 10 * 1024 * 1024
+    ) {
+      return null;
+    }
 
     const text = await response.text();
     if (!text.trim()) return null;
@@ -237,6 +213,8 @@ export async function fetchWebPage(
     return { content: text, isHtml };
   } catch {
     return null;
+  } finally {
+    clearTimeout(timer);
   }
 }
 
@@ -1338,7 +1316,7 @@ function collectHeaders(
 ): Record<string, string> {
   const sep = value.indexOf(":");
   if (sep <= 0) {
-    throw new Error(`Invalid header format: "${value}". Use "Key: Value"."`);
+    throw new Error(`Invalid header format: "${value}". Use "Key: Value".`);
   }
   const key = value.slice(0, sep).trim();
   const val = value.slice(sep + 1).trim();

--- a/packages/context/src/cli.ts
+++ b/packages/context/src/cli.ts
@@ -23,7 +23,11 @@ import { loadAuth, saveAuth } from "./auth.js";
 import { getServerUrl } from "./config.js";
 import { initDatabase } from "./database.js";
 import { downloadPackage, searchPackages } from "./download.js";
-import { buildFetchOptions } from "./fetch.js";
+import {
+  buildFetchOptions,
+  fetchWithTimeout,
+  readResponseText,
+} from "./fetch.js";
 import {
   checkoutRef,
   cloneRepository,
@@ -172,13 +176,13 @@ export async function fetchWebPage(
   fetchImpl: typeof fetch = fetch,
   timeoutMs: number = 30_000,
 ): Promise<FetchedWebPage | null> {
-  const controller = new AbortController();
-  const timer = setTimeout(() => controller.abort(), timeoutMs);
   try {
-    const response = await fetchImpl(url, {
-      ...buildFetchOptions(url),
-      signal: controller.signal,
-    });
+    const response = await fetchWithTimeout(
+      fetchImpl,
+      url,
+      buildFetchOptions(url),
+      timeoutMs,
+    );
     if (!response.ok) return null;
 
     const contentLength = response.headers.get("content-length");
@@ -189,8 +193,8 @@ export async function fetchWebPage(
       return null;
     }
 
-    const text = await response.text();
-    if (!text.trim()) return null;
+    const text = await readResponseText(response);
+    if (!text || !text.trim()) return null;
 
     const contentType =
       response.headers.get("content-type")?.toLowerCase() ?? "";
@@ -213,8 +217,6 @@ export async function fetchWebPage(
     return { content: text, isHtml };
   } catch {
     return null;
-  } finally {
-    clearTimeout(timer);
   }
 }
 

--- a/packages/context/src/fetch.ts
+++ b/packages/context/src/fetch.ts
@@ -41,3 +41,57 @@ export function buildFetchOptions(
 
   return { headers: baseHeaders, redirect: "follow" };
 }
+
+const DEFAULT_MAX_BYTES = 10 * 1024 * 1024;
+
+/**
+ * Perform a fetch with an AbortController timeout.
+ * Rejects with an AbortError if the request takes longer than timeoutMs.
+ */
+export async function fetchWithTimeout(
+  fetchImpl: typeof fetch,
+  url: string,
+  init: RequestInit,
+  timeoutMs: number,
+): Promise<Response> {
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), timeoutMs);
+  try {
+    return await fetchImpl(url, {
+      ...init,
+      signal: controller.signal,
+    });
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
+/**
+ * Read a fetch Response body as text, capping the total bytes read.
+ * Returns null if the body exceeds maxBytes.
+ */
+export async function readResponseText(
+  response: Response,
+  maxBytes: number = DEFAULT_MAX_BYTES,
+): Promise<string | null> {
+  const reader = response.body?.getReader();
+  if (!reader) return null;
+
+  const decoder = new TextDecoder();
+  let text = "";
+  let bytesRead = 0;
+
+  try {
+    while (true) {
+      const { done, value } = await reader.read();
+      if (done) break;
+      bytesRead += value.length;
+      if (bytesRead > maxBytes) return null;
+      text += decoder.decode(value, { stream: true });
+    }
+    text += decoder.decode();
+    return text;
+  } catch {
+    return null;
+  }
+}

--- a/packages/context/src/fetch.ts
+++ b/packages/context/src/fetch.ts
@@ -1,0 +1,43 @@
+/**
+ * Shared fetch utilities for making HTTP requests with consistent headers
+ * and platform authentication.
+ */
+
+import { loadAuth, withPlatformAuth } from "./auth.js";
+
+/** Default browser-like headers to bypass basic bot protection. */
+export const DEFAULT_FETCH_HEADERS: Record<string, string> = {
+  "User-Agent":
+    "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/135.0.0.0 Safari/537.36",
+  Accept:
+    "text/html,application/xhtml+xml,application/xml;q=0.9,image/avif,image/webp,*/*;q=0.8",
+  "Accept-Language": "en-US,en;q=0.5",
+  "Accept-Encoding": "gzip, deflate, br",
+  DNT: "1",
+  Connection: "keep-alive",
+  "Upgrade-Insecure-Requests": "1",
+  "Sec-Fetch-Dest": "document",
+  "Sec-Fetch-Mode": "navigate",
+  "Sec-Fetch-Site": "none",
+  "Sec-Fetch-User": "?1",
+};
+
+/** Build fetch init options, merging platform auth and optional cookies from env. */
+export function buildFetchOptions(
+  url?: string,
+  extraHeaders?: Record<string, string>,
+): RequestInit {
+  const baseHeaders = { ...DEFAULT_FETCH_HEADERS, ...extraHeaders };
+
+  const cookieEnv = process.env.CONTEXT_FETCH_COOKIES;
+  if (cookieEnv) {
+    baseHeaders.Cookie = cookieEnv;
+  }
+
+  if (url) {
+    const auth = loadAuth();
+    return withPlatformAuth(auth, url, baseHeaders);
+  }
+
+  return { headers: baseHeaders, redirect: "follow" };
+}

--- a/packages/context/src/html.ts
+++ b/packages/context/src/html.ts
@@ -21,6 +21,11 @@ for (const tag of [
   "header",
   "noscript",
   "title",
+  "aside",
+  "iframe",
+  "form",
+  "svg",
+  "canvas",
 ]) {
   turndown.remove(tag);
 }

--- a/packages/context/src/llms-txt.ts
+++ b/packages/context/src/llms-txt.ts
@@ -10,7 +10,7 @@
  * doesn't need link following.
  */
 
-import { buildFetchOptions } from "./fetch.js";
+import { buildFetchOptions, fetchWithTimeout } from "./fetch.js";
 import type { MarkdownFile } from "./package-builder.js";
 
 /** A link extracted from an llms.txt index. */
@@ -87,14 +87,13 @@ async function fetchLink(
   fetchImpl: typeof fetch,
   timeoutMs: number,
 ): Promise<FetchedDoc | null> {
-  const controller = new AbortController();
-  const timer = setTimeout(() => controller.abort(), timeoutMs);
   try {
-    const init = buildFetchOptions(url);
-    const response = await fetchImpl(url, {
-      ...init,
-      signal: controller.signal,
-    });
+    const response = await fetchWithTimeout(
+      fetchImpl,
+      url,
+      buildFetchOptions(url),
+      timeoutMs,
+    );
     if (!response.ok) return null;
 
     const text = await response.text();
@@ -113,8 +112,6 @@ async function fetchLink(
     return { url, file: { path, content: text } };
   } catch {
     return null;
-  } finally {
-    clearTimeout(timer);
   }
 }
 

--- a/packages/context/src/llms-txt.ts
+++ b/packages/context/src/llms-txt.ts
@@ -10,6 +10,7 @@
  * doesn't need link following.
  */
 
+import { buildFetchOptions } from "./fetch.js";
 import type { MarkdownFile } from "./package-builder.js";
 
 /** A link extracted from an llms.txt index. */
@@ -89,16 +90,10 @@ async function fetchLink(
   const controller = new AbortController();
   const timer = setTimeout(() => controller.abort(), timeoutMs);
   try {
+    const init = buildFetchOptions(url);
     const response = await fetchImpl(url, {
+      ...init,
       signal: controller.signal,
-      headers: {
-        "User-Agent":
-          "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/135.0.0.0 Safari/537.36",
-        Accept:
-          "text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8",
-        "Accept-Language": "en-US,en;q=0.5",
-      },
-      redirect: "follow",
     });
     if (!response.ok) return null;
 

--- a/packages/context/src/llms-txt.ts
+++ b/packages/context/src/llms-txt.ts
@@ -89,7 +89,17 @@ async function fetchLink(
   const controller = new AbortController();
   const timer = setTimeout(() => controller.abort(), timeoutMs);
   try {
-    const response = await fetchImpl(url, { signal: controller.signal });
+    const response = await fetchImpl(url, {
+      signal: controller.signal,
+      headers: {
+        "User-Agent":
+          "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/135.0.0.0 Safari/537.36",
+        Accept:
+          "text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8",
+        "Accept-Language": "en-US,en;q=0.5",
+      },
+      redirect: "follow",
+    });
     if (!response.ok) return null;
 
     const text = await response.text();

--- a/packages/context/src/package-builder.test.ts
+++ b/packages/context/src/package-builder.test.ts
@@ -269,4 +269,43 @@ Run the install command.
       db.close();
     }
   });
+
+  it("extracts sections from representative HTML pages", () => {
+    const html = `<!DOCTYPE html>
+<html>
+<head><title>Blog Post</title></head>
+<body>
+<nav><a href="/">Home</a></nav>
+<article>
+<h1>Things I Don't Know as of 2018</h1>
+<p>People often assume that I know way more than I actually do.</p>
+<h2>Backend</h2>
+<p>I don't know how to configure a Linux server.</p>
+<h2>CSS</h2>
+<p>I can't center a div without googling.</p>
+</article>
+<footer>Copyright 2018</footer>
+<script>console.log('hi');</script>
+</body>
+</html>`;
+
+    const result = buildPackage(
+      testDbPath,
+      [{ path: "example.com/post.html", content: html }],
+      { name: "test-html", version: "1.0.0" },
+    );
+
+    expect(result.sectionCount).toBeGreaterThan(0);
+
+    const db = openDatabase(testDbPath, { readonly: true });
+    try {
+      const chunks = db
+        .prepare("SELECT section_title FROM chunks ORDER BY id")
+        .all() as { section_title: string }[];
+
+      expect(chunks.length).toBeGreaterThan(0);
+    } finally {
+      db.close();
+    }
+  });
 });


### PR DESCRIPTION
Closes #72

## Summary

`context add <url>` now falls back to fetching the page **directly** when `llms.txt` is not found. This enables ingesting blog posts, articles, documentation pages, raw markdown files, and any other web content into Context.

## What Changed

### Core Feature: Arbitrary URL Fallback
- After trying `llms.txt` / `llms-full.txt`, the CLI now fetches the original URL as a single-document package
- `suggestPackageNameFromUrl()` derives meaningful names from URL paths (e.g. `overreacted.io-things-i-dont-know-as-of-2018`)
- `fetchWebPage()` handles content-type detection, HTML sniffing, and rejects binaries (PDFs, images)

### Bot Protection Bypass
- All HTTP fetches now send realistic browser headers (`User-Agent`, `Accept`, `Sec-Fetch-*`, etc.)
- Unlocks Substack, Medium, and other platforms that block plain `fetch` requests

### Per-Platform Authentication
- New `context auth` subcommands: `add`, `list`, `remove`
- Store cookies per domain in `~/.context/auth.json`
- Automatic parent-domain matching (e.g. `rafahari.substack.com` → `substack.com` auth)
- Enables access to subscriber-only content for users with legitimate subscriptions

### Tests
- New `auth.test.ts` — 8 tests for domain matching and header merging
- Extended `cli.test.ts` — 12 new tests for `suggestPackageNameFromUrl` and `fetchWebPage`
- **All 145 tests pass**

## Validation

```bash
# Free blog post
context add https://overreacted.io/things-i-dont-know-as-of-2018/
# → Installed: overreacted.io-things-i-dont-know-as-of-2018@latest (48 KB, 3 sections)

# Raw markdown
context add https://raw.githubusercontent.com/neuledge/context/main/README.md --name context-readme
# → Installed: context-readme@latest (32 KB, 1 section)

# Subscriber content (with your own cookies)
context auth add substack.com --cookies "substack.sid=YOUR_SID"
context add https://yoursubstack.substack.com/p/article --name my-article
```

## Checklist

- [x] `pnpm lint` passes
- [x] `pnpm build` passes
- [x] `pnpm test` passes (145/145)
- [x] Changeset added
- [x] Tests added for new functionality
