### PR TITLE
chore: prepare v1.0.0 release

### DIFF
--- a/.changeset/v1-release.md
+++ b/.changeset/v1-release.md
@@ -1,0 +1,5 @@
+---
+"@neuledge/context": major
+---
+
+Release v1.0.0


### PR DESCRIPTION
## Summary
- Adds a `major` changeset to bump `@neuledge/context` from 0.9.0 → 1.0.0
- Once merged to `main`, the changesets "Version Packages" PR will roll up the unreleased entries (0.9.0 already shipped) and publish v1.0.0

## Test plan
- [x] `pnpm install --frozen-lockfile`
- [x] `pnpm lint`
- [x] `pnpm build`
- [x] `pnpm test` (184 tests passing across both packages)

https://claude.ai/code/session_01TGVWCbDRiBSA2rLhkm6m2Q

---
_Generated by [Claude Code](https://claude.ai/code/session_01TGVWCbDRiBSA2rLhkm6m2Q)_