### PR TITLE
fix: install git in Docker runtime image

### DIFF
--- a/.changeset/docker-install-git.md
+++ b/.changeset/docker-install-git.md
@@ -1,0 +1,5 @@
+---
+"@neuledge/context": patch
+---
+
+Install `git` in the Docker runtime image so cloning GitHub URLs works out of the box (fixes `Git clone failed: /bin/sh: 1: git: not found`).

--- a/packages/context/Dockerfile
+++ b/packages/context/Dockerfile
@@ -13,6 +13,10 @@ FROM node:22-bookworm-slim AS runtime
 
 WORKDIR /app
 
+RUN apt-get update \
+  && apt-get install -y --no-install-recommends git ca-certificates \
+  && rm -rf /var/lib/apt/lists/*
+
 COPY --from=build /app/packages/context/dist ./dist
 COPY --from=build /app/packages/context/package.json ./package.json
 


### PR DESCRIPTION
## Summary
- Fixes #79: `node:22-bookworm-slim` does not ship `git`, so any flow that adds a GitHub URL inside the published Docker image fails with `Git clone failed: /bin/sh: 1: git: not found`.
- Installs `git` (plus `ca-certificates` for reliable HTTPS clones) in the runtime stage of `packages/context/Dockerfile`.
- `git` is required not just for the initial `cloneRepository` (`packages/context/src/git.ts:212`) but also for `detectVersion`, `fetchTagsWithMetadata`, and `checkoutRef`, which all shell out to `git`.

## Test plan
- [x] `pnpm install --frozen-lockfile`
- [x] `pnpm lint`
- [x] `pnpm build`
- [x] `pnpm test` (149 + 35 tests passing)
- [ ] Manual: build the Docker image and run `context add https://github.com/<owner>/<repo>` inside the container to confirm the clone succeeds.

https://claude.ai/code/session_01BNjzMqqmzWbsxPT5HgrXCN

---
_Generated by [Claude Code](https://claude.ai/code/session_01BNjzMqqmzWbsxPT5HgrXCN)_