### PR TITLE
fix(docker): bundle prebuilt better-sqlite3 binding via pnpm deploy

### DIFF
--- a/packages/context/Dockerfile
+++ b/packages/context/Dockerfile
@@ -4,9 +4,13 @@ WORKDIR /app
 
 COPY . .
 
+# pnpm deploy assembles a self-contained folder with prod deps and the
+# already-built better-sqlite3 native binding, avoiding a second install
+# (and the --ignore-scripts trap that left the .node file missing).
 RUN corepack enable \
   && pnpm install --frozen-lockfile \
-  && pnpm --filter @neuledge/context build
+  && pnpm --filter @neuledge/context build \
+  && pnpm --filter @neuledge/context deploy --prod --legacy /deploy
 
 
 FROM node:22-bookworm-slim AS runtime
@@ -17,10 +21,7 @@ RUN apt-get update \
   && apt-get install -y --no-install-recommends git ca-certificates \
   && rm -rf /var/lib/apt/lists/*
 
-COPY --from=build /app/packages/context/dist ./dist
-COPY --from=build /app/packages/context/package.json ./package.json
-
-RUN npm install --omit=dev --ignore-scripts
+COPY --from=build /deploy ./
 
 EXPOSE 8080
 


### PR DESCRIPTION
## Summary

Fixes #78 — `Error: Could not locate the bindings file` when anything inside the Docker image loads `better-sqlite3`.

## Root cause

The runtime stage of `packages/context/Dockerfile` ran:

```
npm install --omit=dev --ignore-scripts
```

`--ignore-scripts` skips `better-sqlite3`'s install script (which normally has `prebuild-install` fetch the prebuilt `.node` binary). The package is on disk but its native binding is not, so `require("better-sqlite3")` walks every fallback path and throws.

Although `src/database.ts` does `try { require("better-sqlite3") } catch { ... fall back to sql.js }`, any other tool inside the container (e.g. `npm install <pkg>` while exec'd in) that touches the module hits the raw error.

## Fix

Use `pnpm deploy --prod --legacy` in the build stage to assemble a self-contained folder under `/deploy` that already contains:
- `dist/`
- `package.json`
- `node_modules/` with the compiled `better_sqlite3.node` binary

The runtime stage then just `COPY --from=build /deploy ./` — no second install, no `--ignore-scripts` foot-gun, and no build tools needed in the runtime image.

`--legacy` is required because pnpm 10 otherwise expects `inject-workspace-packages=true`; we don't need injection here since `@neuledge/context` has no workspace dependencies.

## Verified locally

```
$ pnpm --filter @neuledge/context deploy --prod --legacy /tmp/deploy-test
$ ls /tmp/deploy-test/node_modules/better-sqlite3/build/Release/
better_sqlite3.node
$ cd /tmp/deploy-test && node -e "const Db=require('better-sqlite3'); const db=new Db(':memory:'); db.exec('CREATE TABLE t(x); INSERT INTO t VALUES(1)'); console.log(db.prepare('SELECT x FROM t').get());"
{ x: 1 }
```

## Test plan

- [ ] `docker build -f packages/context/Dockerfile .` succeeds
- [ ] Container starts and serves on 8080
- [ ] Inside the container, `node -e "require('better-sqlite3')"` no longer throws


---
_Generated by [Claude Code](https://claude.ai/code/session_01922bvjz9JvrabpZagioN11)_