### PR TITLE
fix(registry): retry transient 5xx errors from registry APIs

### DIFF
--- a/packages/registry/package.json
+++ b/packages/registry/package.json
@@ -27,6 +27,7 @@
   "dependencies": {
     "@neuledge/context": "workspace:*",
     "commander": "^14.0.0",
+    "p-retry": "^8.0.0",
     "yaml": "^2.8.2",
     "zod": "^4.3.6"
   },

--- a/packages/registry/src/version-check.test.ts
+++ b/packages/registry/src/version-check.test.ts
@@ -154,6 +154,42 @@ describe("discoverVersions", () => {
     await expect(discoverVersions(mockDefinition)).rejects.toThrow("404");
   });
 
+  it("retries on transient 5xx errors and succeeds", async () => {
+    vi.useFakeTimers();
+    const mockFetch = vi.mocked(fetch);
+    mockFetch
+      .mockResolvedValueOnce({ ok: false, status: 504 } as Response)
+      .mockResolvedValueOnce({ ok: false, status: 503 } as Response)
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({
+          versions: { "2.0.0": {} },
+          time: { "2.0.0": "2024-01-01T00:00:00Z" },
+        }),
+      } as Response);
+
+    const promise = discoverVersions(mockDefinition);
+    await vi.runAllTimersAsync();
+    const versions = await promise;
+
+    expect(mockFetch).toHaveBeenCalledTimes(3);
+    expect(versions.map((v) => v.version)).toEqual(["2.0.0"]);
+    vi.useRealTimers();
+  });
+
+  it("throws after exhausting retries on persistent 5xx", async () => {
+    vi.useFakeTimers();
+    const mockFetch = vi.mocked(fetch);
+    mockFetch.mockResolvedValue({ ok: false, status: 504 } as Response);
+
+    const promise = discoverVersions(mockDefinition);
+    const assertion = expect(promise).rejects.toThrow("504");
+    await vi.runAllTimersAsync();
+    await assertion;
+    expect(mockFetch).toHaveBeenCalledTimes(4);
+    vi.useRealTimers();
+  });
+
   it("returns 'latest' for unversioned definitions without calling registry", async () => {
     const mockFetch = vi.mocked(fetch);
     const unversioned: UnversionedDefinition = {

--- a/packages/registry/src/version-check.ts
+++ b/packages/registry/src/version-check.ts
@@ -5,6 +5,7 @@
  * filters to defined ranges, and deduplicates to latest-patch-per-minor.
  */
 
+import pRetry, { AbortError } from "p-retry";
 import {
   compareSemver,
   isVersioned,
@@ -196,44 +197,26 @@ async function fetchMavenVersions(packageName: string): Promise<VersionInfo[]> {
 }
 
 /**
- * Fetch with retry on transient failures (5xx responses and network errors).
- * Public registries occasionally return 504/503 under load — retrying with
- * exponential backoff turns a flaky CI job into a reliable one.
+ * Public registries occasionally return 504/503 under load. Retry 5xx and
+ * network errors with exponential backoff; 4xx aborts immediately.
  */
-async function fetchWithRetry(
+function fetchWithRetry(
   url: string,
   registryLabel: string,
   packageName: string,
-  maxAttempts = 4,
 ): Promise<Response> {
-  let lastError: unknown;
-
-  for (let attempt = 1; attempt <= maxAttempts; attempt++) {
-    let res: Response | undefined;
-    try {
-      res = await fetch(url);
-    } catch (err) {
-      lastError = err;
-      if (attempt === maxAttempts) throw err;
-      await sleep(2 ** (attempt - 1) * 1000);
-      continue;
-    }
-
-    if (res.ok) return res;
-
-    const error = new Error(
-      `${registryLabel} returned ${res.status} for ${packageName}`,
-    );
-    if (res.status < 500 || attempt === maxAttempts) throw error;
-    lastError = error;
-    await sleep(2 ** (attempt - 1) * 1000);
-  }
-
-  throw lastError;
-}
-
-function sleep(ms: number): Promise<void> {
-  return new Promise((resolve) => setTimeout(resolve, ms));
+  return pRetry(
+    async () => {
+      const res = await fetch(url);
+      if (res.ok) return res;
+      const error = new Error(
+        `${registryLabel} returned ${res.status} for ${packageName}`,
+      );
+      if (res.status < 500) throw new AbortError(error);
+      throw error;
+    },
+    { retries: 3 },
+  );
 }
 
 function isPrerelease(version: string): boolean {

--- a/packages/registry/src/version-check.ts
+++ b/packages/registry/src/version-check.ts
@@ -121,12 +121,11 @@ export async function discoverVersions(
 }
 
 async function fetchNpmVersions(packageName: string): Promise<VersionInfo[]> {
-  const res = await fetch(
+  const res = await fetchWithRetry(
     `https://registry.npmjs.org/${encodeURIComponent(packageName)}`,
+    `npm registry`,
+    packageName,
   );
-  if (!res.ok) {
-    throw new Error(`npm registry returned ${res.status} for ${packageName}`);
-  }
 
   const data = (await res.json()) as {
     versions?: Record<string, unknown>;
@@ -143,12 +142,11 @@ async function fetchNpmVersions(packageName: string): Promise<VersionInfo[]> {
 }
 
 async function fetchPipVersions(packageName: string): Promise<VersionInfo[]> {
-  const res = await fetch(
+  const res = await fetchWithRetry(
     `https://pypi.org/pypi/${encodeURIComponent(packageName)}/json`,
+    `PyPI`,
+    packageName,
   );
-  if (!res.ok) {
-    throw new Error(`PyPI returned ${res.status} for ${packageName}`);
-  }
 
   const data = (await res.json()) as {
     releases?: Record<string, Array<{ upload_time_iso_8601?: string }>>;
@@ -175,12 +173,11 @@ async function fetchMavenVersions(packageName: string): Promise<VersionInfo[]> {
   }
 
   const query = `g:${groupId}+AND+a:${artifactId}`;
-  const res = await fetch(
+  const res = await fetchWithRetry(
     `https://search.maven.org/solrsearch/select?q=${query}&core=gav&rows=200&wt=json`,
+    `Maven Central`,
+    packageName,
   );
-  if (!res.ok) {
-    throw new Error(`Maven Central returned ${res.status} for ${packageName}`);
-  }
 
   const data = (await res.json()) as {
     response?: {
@@ -196,6 +193,47 @@ async function fetchMavenVersions(packageName: string): Promise<VersionInfo[]> {
       ? new Date(doc.timestamp).toISOString()
       : undefined,
   }));
+}
+
+/**
+ * Fetch with retry on transient failures (5xx responses and network errors).
+ * Public registries occasionally return 504/503 under load — retrying with
+ * exponential backoff turns a flaky CI job into a reliable one.
+ */
+async function fetchWithRetry(
+  url: string,
+  registryLabel: string,
+  packageName: string,
+  maxAttempts = 4,
+): Promise<Response> {
+  let lastError: unknown;
+
+  for (let attempt = 1; attempt <= maxAttempts; attempt++) {
+    let res: Response | undefined;
+    try {
+      res = await fetch(url);
+    } catch (err) {
+      lastError = err;
+      if (attempt === maxAttempts) throw err;
+      await sleep(2 ** (attempt - 1) * 1000);
+      continue;
+    }
+
+    if (res.ok) return res;
+
+    const error = new Error(
+      `${registryLabel} returned ${res.status} for ${packageName}`,
+    );
+    if (res.status < 500 || attempt === maxAttempts) throw error;
+    lastError = error;
+    await sleep(2 ** (attempt - 1) * 1000);
+  }
+
+  throw lastError;
+}
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
 }
 
 function isPrerelease(version: string): boolean {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -109,6 +109,9 @@ importers:
       commander:
         specifier: ^14.0.0
         version: 14.0.2
+      p-retry:
+        specifier: ^8.0.0
+        version: 8.0.0
       yaml:
         specifier: ^2.8.2
         version: 2.8.2
@@ -1295,6 +1298,10 @@ packages:
     resolution: {integrity: sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==}
     engines: {node: '>=0.10.0'}
 
+  is-network-error@1.3.2:
+    resolution: {integrity: sha512-PhBY86zaxNZUuWP6h13Vu5oFe0XY6/UlKzQnYFELzGVHygP3MxmvTfYSG7GN3aIab/iWudSMgjSnG9Dq+nHrgA==}
+    engines: {node: '>=16'}
+
   is-number@7.0.0:
     resolution: {integrity: sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==}
     engines: {node: '>=0.12.0'}
@@ -1573,6 +1580,10 @@ packages:
   p-map@2.1.0:
     resolution: {integrity: sha512-y3b8Kpd8OAN444hxfBbFfj1FY/RjtTd8tzYwhUqNYXx0fXx2iX4maP4Qr6qhIKbQXI02wTLAda4fYUbDagTUFw==}
     engines: {node: '>=6'}
+
+  p-retry@8.0.0:
+    resolution: {integrity: sha512-kFVqH1HxOHp8LupNsOys7bSV09VYTRLxarH/mokO4Rqhk6wGi70E0jh4VzvVGXfEVNggHoHLAMWsQqHyU1Ey9A==}
+    engines: {node: '>=22'}
 
   p-try@2.2.0:
     resolution: {integrity: sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==}
@@ -3241,6 +3252,8 @@ snapshots:
     dependencies:
       is-extglob: 2.1.1
 
+  is-network-error@1.3.2: {}
+
   is-number@7.0.0: {}
 
   is-plain-obj@4.1.0: {}
@@ -3580,6 +3593,10 @@ snapshots:
       p-limit: 2.3.0
 
   p-map@2.1.0: {}
+
+  p-retry@8.0.0:
+    dependencies:
+      is-network-error: 1.3.2
 
   p-try@2.2.0: {}
 


### PR DESCRIPTION
## Summary
- Wraps the npm/PyPI/Maven Central fetches in `version-check.ts` with a retry helper (up to 4 attempts, 1s/2s/4s exponential backoff) so transient 5xx responses no longer abort the `publish-all` CI job.
- 4xx responses still fail fast — only 5xx and network errors retry.
- Triggered by a real CI failure where Maven Central returned `504` for `io.micrometer:micrometer-core`.

## Test plan
- [x] `pnpm --filter @neuledge/registry test` — 37 passed, including new cases for retry-on-5xx and retry-exhaustion
- [x] `pnpm --filter @neuledge/registry lint`
- [x] `pnpm --filter @neuledge/registry build`


---
_Generated by [Claude Code](https://claude.ai/code/session_011pr7ac5NF87a8onAZ4w4ef)_