### PR TITLE
fix(registry): point nx 22.7+ at astro-docs and index .mdoc files

### DIFF
--- a/.changeset/mdoc-extension-support.md
+++ b/.changeset/mdoc-extension-support.md
@@ -1,0 +1,5 @@
+---
+"@neuledge/context": patch
+---
+
+Recognize `.mdoc` (Markdoc) files when scanning a repository for documentation. Sites built on Astro Starlight (e.g. Nx) ship docs in this format, and they were previously skipped.

--- a/packages/context/src/build.ts
+++ b/packages/context/src/build.ts
@@ -313,7 +313,7 @@ export function parseMarkdown(source: string, filePath: string): ParsedDoc {
     filePath
       .split("/")
       .pop()
-      ?.replace(/\.(md|mdx|qmd|rmd|adoc|rst)$/, "") ||
+      ?.replace(/\.(md|mdx|mdoc|qmd|rmd|adoc|rst)$/, "") ||
     "Untitled";
 
   // Remove frontmatter and JSX import statements from source for extraction

--- a/packages/context/src/git.ts
+++ b/packages/context/src/git.ts
@@ -117,6 +117,7 @@ const FIXTURE_SUFFIXES = ["expect", "test", "spec"];
 const DOCUMENTATION_EXTENSIONS = [
   ".md",
   ".mdx",
+  ".mdoc",
   ".qmd",
   ".rmd",
   ".adoc",

--- a/registry/npm/nx.yaml
+++ b/registry/npm/nx.yaml
@@ -3,7 +3,16 @@ description: "Smart, fast, and extensible build system for monorepos"
 repository: https://github.com/nrwl/nx
 
 versions:
+  # Nx 22.7.0 moved docs from `docs/` to `astro-docs/src/content/docs/`
+  # (Markdoc-based Astro site) and dropped the top-level `docs/` folder.
+  - min_version: "22.7.0"
+    source:
+      type: git
+      url: https://github.com/nrwl/nx
+      docs_path: astro-docs/src/content/docs
+    tag_pattern: "{version}"
   - min_version: "17.0.0"
+    max_version: "22.7.0"
     source:
       type: git
       url: https://github.com/nrwl/nx


### PR DESCRIPTION
## Summary

`publish-all --since 2` failed on `npm/nx@22.7.2` with `Directory not found: /tmp/context-git-…/docs`. Nx 22.7.0 deleted the top-level `docs/` directory and migrated all documentation into `astro-docs/src/content/docs/` as Markdoc (`.mdoc`) files (Astro Starlight site).

- `registry/npm/nx.yaml` — split into two version ranges: `22.7.0+` → `astro-docs/src/content/docs`, `17.0.0` – `<22.7.0` → `docs` (preserves the path already-published older versions used).
- `packages/context/src/git.ts` — add `.mdoc` to `DOCUMENTATION_EXTENSIONS`; previously `.mdoc` files were silently skipped, so even the right `docs_path` would have produced zero files.
- `packages/context/src/build.ts` — extend `parseMarkdown`'s title-stripping regex to handle `.mdoc` filenames.
- `.changeset/mdoc-extension-support.md` — patch bump for `@neuledge/context`.

## Test plan

- [x] `node packages/registry/dist/cli.js build nx 22.7.2` → `Built (1901 sections, 575936 tokens)`
- [x] Version-range resolution: `17.0.0` / `21.0.0` / `22.6.5` → `docs`; `22.7.0` / `22.7.2` / `23.0.0` → `astro-docs/src/content/docs`
- [x] `pnpm lint` passes
- [x] `pnpm test` passes (157 context + 37 registry tests)

https://claude.ai/code/session_012qtew8ebkKeL7T6gaGGcTv

---
_Generated by [Claude Code](https://claude.ai/code/session_012qtew8ebkKeL7T6gaGGcTv)_