### PR TITLE
fix(registry): update express docs_path after expressjs.com restructure

### DIFF
--- a/registry/npm/express.yaml
+++ b/registry/npm/express.yaml
@@ -5,4 +5,4 @@ repository: https://github.com/expressjs/express
 source:
   type: git
   url: https://github.com/expressjs/expressjs.com
-  docs_path: en
+  docs_path: src/content/docs


### PR DESCRIPTION
## Summary
- The `expressjs.com` site migrated to Astro and moved English docs from `/en` to `/src/content/docs/en`, breaking the scheduled `publish-all` CI job with `Directory not found: /tmp/context-git-…/en`.
- Point `docs_path` at `src/content/docs` so the existing locale filter resolves the `en/` subdirectory.

## Test plan
- [x] `pnpm --filter @neuledge/registry registry build express` — built 60 sections / 20,794 tokens locally.
- [ ] Scheduled `publish-all` workflow succeeds on next run.

---
_Generated by [Claude Code](https://claude.ai/code/session_017Ah3PpcsxGhKdSZEL8zx6T)_