### PR TITLE
fix(registry): point date-fns 4.3+ at the new monorepo docs path

### DIFF
--- a/registry/npm/date-fns.yaml
+++ b/registry/npm/date-fns.yaml
@@ -3,7 +3,17 @@ description: "Modern JavaScript date utility library"
 repository: https://github.com/date-fns/date-fns
 
 versions:
+  # date-fns 4.3.0 moved to a pnpm monorepo layout: the top-level `docs/`
+  # directory was removed and the markdown docs now live at
+  # `pkgs/core/docs/` alongside the `@date-fns/core` package.
+  - min_version: "4.3.0"
+    source:
+      type: git
+      url: https://github.com/date-fns/date-fns
+      docs_path: pkgs/core/docs
+    tag_pattern: "v{version}"
   - min_version: "3.0.0"
+    max_version: "4.3.0"
     source:
       type: git
       url: https://github.com/date-fns/date-fns


### PR DESCRIPTION
date-fns 4.3.0 migrated to a pnpm monorepo layout and removed the
top-level `docs/` directory; the markdown docs now live at
`pkgs/core/docs/` alongside the `@date-fns/core` package, which broke
publish-all for `npm/date-fns@4.3.0`. Add a versioned range for 4.3.0+
pointing at the new path and keep the existing range for 3.0.0–4.2.x.