### PR TITLE
fix(context): ignore non-string frontmatter title/description

### DIFF
--- a/.changeset/curly-lions-cheer.md
+++ b/.changeset/curly-lions-cheer.md
@@ -1,0 +1,5 @@
+---
+"@neuledge/context": patch
+---
+
+Ignore non-string `title`/`description` frontmatter values when parsing docs. Previously a frontmatter field that parsed to a non-string (e.g. an object) propagated into the document title and broke package building with "Too few parameter values were provided". Such values now fall back to the derived title instead of crashing the build.

--- a/packages/context/src/build.test.ts
+++ b/packages/context/src/build.test.ts
@@ -27,6 +27,27 @@ Install the package.
     expect(result.frontmatter.description).toBe("Learn how to get started");
   });
 
+  it("ignores non-string frontmatter title (malformed YAML)", () => {
+    // Svelte 5's docs use unquoted titles like `{let/const ...}` that YAML
+    // parses into an object, which must not leak into docTitle (it would break
+    // SQLite parameter binding with "Too few parameter values were provided").
+    const source = `---
+title: {let/const ...}
+---
+
+## Declaration tags
+
+Some content about declaration tags.
+`;
+
+    const result = parseMarkdown(source, "docs/declaration-tags.md");
+
+    expect(result.frontmatter.title).toBeUndefined();
+    // docTitle falls back to the filename-derived title
+    expect(typeof result.sections[0]?.docTitle).toBe("string");
+    expect(result.sections[0]?.docTitle).toBe("declaration-tags");
+  });
+
   it("chunks content by h2 sections", () => {
     const source = `---
 title: Routing

--- a/packages/context/src/build.ts
+++ b/packages/context/src/build.ts
@@ -141,7 +141,15 @@ function extractFrontmatter(tree: Root): DocFrontmatter {
   if (!yamlNode) return {};
 
   try {
-    return parseYaml(yamlNode.value) as DocFrontmatter;
+    // Validate types rather than blindly casting: malformed frontmatter can
+    // parse title/description into non-strings (e.g. a bare value the YAML
+    // parser reads as a map), which later breaks SQLite parameter binding.
+    const data = parseYaml(yamlNode.value) as Record<string, unknown> | null;
+    return {
+      title: typeof data?.title === "string" ? data.title : undefined,
+      description:
+        typeof data?.description === "string" ? data.description : undefined,
+    };
   } catch {
     return {};
   }


### PR DESCRIPTION
## Problem

The scheduled `publish-all` job failed for `npm/svelte@5.56.0` with:

```
FAILED npm/svelte@5.56.0: Too few parameter values were provided
```

All other packages built/published fine.

## Root cause

`Too few parameter values were provided` is a **better-sqlite3** error: when a positional argument to a prepared statement's `.run()` is a plain JS object, better-sqlite3 interprets it as a *named-parameters* bind map, consuming one slot — leaving fewer anonymous values than `?` placeholders.

The offending object originated in one Svelte 5.56.0 doc file, `documentation/docs/03-template-syntax/11-declaration-tags.md`, whose frontmatter is:

```yaml
---
title: {let/const ...}
---
```

`{let/const ...}` is unquoted and is valid YAML flow-mapping syntax, so the parser produced the object `{ "let/const ...": null }` instead of a string. `extractFrontmatter` blind-cast the parsed YAML, and `parseMarkdown` then used that truthy object as `docTitle`, which flowed into `insertChunk.run(...)` (6 placeholders) at `package-builder.ts:117` and crashed the build.

Other svelte titles like `{#if ...}` / `{@render ...}` start with `{#`/`{@`, which YAML rejects as flow maps and keeps as strings — which is why only this one package failed.

## Fix

`extractFrontmatter` now keeps `title`/`description` only when they are actually strings, otherwise drops them so `docTitle` falls back to the filename-derived title.

## Validation

- Reproduced the crash before the fix; after the fix `registry build svelte 5.56.0` → **Built: 284 sections, 68643 tokens** (exit 0).
- `@neuledge/context` tests: **158 passed** (added a regression test that fails on old code, passes on fix).
- Lint and build pass for `@neuledge/context`.
- Changeset added (`@neuledge/context` patch).

https://claude.ai/code/session_01Dk6cdQKeX3Lr1eDoL1uTXM

---
_Generated by [Claude Code](https://claude.ai/code/session_01Dk6cdQKeX3Lr1eDoL1uTXM)_