### PR TITLE
fix(registry): skip publish when git tag not pushed yet

### DIFF
--- a/.changeset/quiet-pandas-jump.md
+++ b/.changeset/quiet-pandas-jump.md
@@ -1,0 +1,5 @@
+---
+"@neuledge/context": minor
+---
+
+Add `isMissingRefError` helper to detect git "ref not found" errors (e.g. when a registry publishes a version before its git tag is pushed)

--- a/packages/context/src/git.test.ts
+++ b/packages/context/src/git.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest";
 import {
   findLatestStableVersion,
+  isMissingRefError,
   isTransientGitError,
   parseMonorepoTag,
 } from "./git.js";
@@ -36,6 +37,27 @@ describe("isTransientGitError", () => {
     expect(
       isTransientGitError("fatal: Authentication failed for 'https://...'"),
     ).toBe(false);
+  });
+});
+
+describe("isMissingRefError", () => {
+  it("detects a tag not pushed yet (npm ahead of git)", () => {
+    expect(
+      isMissingRefError(
+        "Git clone failed: Cloning into '/tmp/context-git-9itQYk'...\nfatal: Remote branch v4.1.9 not found in upstream origin",
+      ),
+    ).toBe(true);
+  });
+
+  it("detects a missing pathspec/reference on checkout", () => {
+    expect(
+      isMissingRefError("error: pathspec 'v4.1.9' did not match any file(s)"),
+    ).toBe(true);
+  });
+
+  it("rejects transient and unrelated errors", () => {
+    expect(isMissingRefError("Could not resolve host: github.com")).toBe(false);
+    expect(isMissingRefError("remote: Repository not found.")).toBe(false);
   });
 });
 

--- a/packages/context/src/git.ts
+++ b/packages/context/src/git.ts
@@ -232,6 +232,25 @@ export function isTransientGitError(message: string): boolean {
 }
 
 /**
+ * Git error patterns indicating the requested ref (tag/branch) doesn't exist
+ * in the remote. Happens when a registry (e.g. npm) publishes a version before
+ * the matching git tag is pushed — a transient state that self-heals once the
+ * tag lands, so callers can skip rather than hard-fail.
+ */
+const MISSING_REF_GIT_ERROR_PATTERNS = [
+  /remote branch .* not found in upstream/i,
+  /could not find remote (branch|ref)/i,
+  /(pathspec|reference) .* did not match/i,
+];
+
+/**
+ * Check if a git error message indicates the requested ref doesn't exist.
+ */
+export function isMissingRefError(message: string): boolean {
+  return MISSING_REF_GIT_ERROR_PATTERNS.some((re) => re.test(message));
+}
+
+/**
  * Synchronous sleep (cloneRepository is sync, so no await available).
  */
 function sleepSync(ms: number): void {

--- a/packages/context/src/index.ts
+++ b/packages/context/src/index.ts
@@ -39,6 +39,7 @@ export {
   extractVersion,
   type GitCloneResult,
   isGitUrl,
+  isMissingRefError,
   type LocalDocsResult,
   parseGitUrl,
   readLocalDocsFiles,

--- a/packages/registry/src/cli.ts
+++ b/packages/registry/src/cli.ts
@@ -7,6 +7,7 @@
 
 import { mkdirSync, rmSync } from "node:fs";
 import { resolve } from "node:path";
+import { isMissingRefError } from "@neuledge/context";
 import { Command } from "commander";
 import {
   buildFromDefinition,
@@ -291,6 +292,13 @@ program
           succeeded++;
         } catch (err) {
           const message = err instanceof Error ? err.message : String(err);
+          // A registry can publish a version before its git tag is pushed.
+          // Skip (don't fail) — the next run picks it up once the tag lands.
+          if (isMissingRefError(message)) {
+            console.log(`  Skipping ${id} (git tag not published yet)`);
+            skipped++;
+            continue;
+          }
           console.error(`  FAILED ${id}: ${message}`);
           failures.push({ id, error: message });
         }


### PR DESCRIPTION
## Problem

The scheduled `publish-all` job failed with:

```
Building npm/vitest@4.1.9...
  FAILED npm/vitest@4.1.9: Git clone failed: ...
fatal: Remote branch v4.1.9 not found in upstream origin
...
Failed: 1
Exit status 1
```

`publish-all` discovers versions from registry APIs (npm/pip/maven) but builds each one by cloning the matching git tag. When a registry publishes a version **before** its git tag is pushed, the clone fails. In this run, `vitest@4.1.9` was published to npm at 07:23 UTC, but the `v4.1.9` GitHub tag didn't exist yet when CI ran at 11:52 (latest tag was `v4.1.8`). One missing tag failed the entire job (36 succeeded, 1 failed → exit 1).

## Fix

Treat a not-yet-pushed tag as a **skip**, not a hard failure — it self-heals on the next run once the tag lands.

- Add `isMissingRefError(message)` to `git.ts` (sibling to the existing `isTransientGitError`), matching git "remote branch/ref not found" / "pathspec did not match" errors. Exported from `@neuledge/context`.
- In `publish-all`, catch these specific errors and count them as skipped rather than pushing them into `failures`.

Genuine build errors (missing docs, real network failures, repo not found) still fail the job as before.

## Validation

- `pnpm lint`, `pnpm build`, `pnpm test` all pass
- Added unit tests for `isMissingRefError`
- Changeset added (`@neuledge/context` minor — new exported helper)

https://claude.ai/code/session_01N5iVzHsBqYBZ5oA78kGNsW

---
_Generated by [Claude Code](https://claude.ai/code/session_01N5iVzHsBqYBZ5oA78kGNsW)_