### PR TITLE
Add httpx to pip registry

### DIFF
--- a/registry/pip/httpx.yaml
+++ b/registry/pip/httpx.yaml
@@ -1,0 +1,13 @@
+name: httpx
+description: "A next-generation HTTP client for Python"
+repository: https://github.com/encode/httpx
+
+versions:
+  - min_version: "0.25.0"
+    source:
+      type: git
+      url: https://github.com/encode/httpx
+      docs_path: docs
+      lang: en
+    tag_pattern: "{version}"
+


### PR DESCRIPTION
## Summary

Adds [httpx](https://www.python-httpx.org/) — a next-generation HTTP client for Python — to the pip registry.

httpx is a widely-used, stable library (30M+ monthly downloads) that provides both synchronous and asynchronous HTTP client functionality. Its documentation lives in the `docs/` directory of the main repository.

## Changes

- New file: `registry/pip/httpx.yaml`
- Format matches existing pip entries (fastapi, pydantic, django, flask)
- `min_version: "0.25.0"` (stable API, docs in `docs/`)
- `tag_pattern: "{version}"` (httpx uses bare version tags, e.g. `0.28.1`)

## Verification

- YAML validates against the existing schema used by other pip entries
- `docs_path: docs` matches the repository structure at https://github.com/encode/httpx/tree/main/docs
- httpx is not already in the registry (confirmed: existing pip entries are django, fastapi, flask, pydantic)