### PR TITLE
fix(context): version resolution, lucia registry build, skipped-file reporting

### DIFF
--- a/.changeset/lucky-otters-repeat.md
+++ b/.changeset/lucky-otters-repeat.md
@@ -1,0 +1,9 @@
+---
+"@neuledge/context": patch
+---
+
+Keep every installed version of a package usable. Installing a second version of the same package (for example upgrading `occtswift` from `1.15.9` to `1.15.10`) used to hide one of them: only one version per name was tracked, and which one survived depended on the order the package files happened to be read in. `context list` showed a single entry, and `context query occtswift@1.15.10` reported "Package not found" even though the package was installed — removing the older version was the only workaround.
+
+All installed versions are now listed and addressable. `name@version` resolves to that exact version, and a bare name resolves to the highest installed version, compared numerically so `1.15.10` beats `1.15.9` (prereleases rank below their release; labels such as `latest` rank below any numbered version). `context serve --libs pkg@1.15.9` now pins the session to exactly that version while a newer one stays installed; a bare `--libs pkg` exposes every installed version.
+
+`context remove` no longer ignores the version in its argument: `context remove pkg@1.15.9` removes exactly that version, and a bare name is refused with the list of installed versions when there is more than one, instead of deleting an arbitrary one. `context add` now points out when the version just installed is not the one a bare name resolves to.

--- a/packages/context/README.md
+++ b/packages/context/README.md
@@ -479,17 +479,24 @@ $ context list
 Installed packages:
 
   nextjs@16.0              4.2 MB    847 sections
+  nextjs@15.5              3.9 MB    790 sections
   react@18                 2.1 MB    423 sections
 
-Total: 2 packages (6.3 MB)
+Total: 3 packages (10.2 MB)
 ```
+
+Several versions of the same package can be installed side by side; each name is listed newest first. Commands that take a bare name (`context query react`, `context serve --libs react`) use the highest installed version.
 
 ### `context remove <name>`
 
-Remove a package.
+Remove a package. Pass `name@version` to remove a specific version. A bare name
+is only accepted when a single version of that package is installed — otherwise
+the command lists the installed versions and asks you to pick one, so nothing is
+deleted by guesswork.
 
 ```bash
 context remove nextjs
+context remove nextjs@16.0
 ```
 
 ### `context auth`
@@ -531,7 +538,7 @@ context serve --libs react next@15.0.4
 |--------|-------------|
 | `--http [port]` | Start as HTTP server instead of stdio (default port: 8080) |
 | `--host <host>` | Host to bind to (default: 127.0.0.1) |
-| `--libs <names...>` | Restrict the session to a fixed set of installed libraries. Each entry is a name (`react`) or `name@version` (`react@18.3.1`). When set, `search_packages` and `download_package` are hidden so the session is locked to that list. Useful for per-project scoping when you have many packages installed globally. |
+| `--libs <names...>` | Restrict the session to a fixed set of installed libraries. Each entry is a name (`react`, exposing every installed version) or `name@version` (`react@18.3.1`, exposing only that version). When set, `search_packages` and `download_package` are hidden so the session is locked to that list. Useful for per-project scoping when you have many packages installed globally. |
 
 The HTTP transport uses the [MCP Streamable HTTP](https://modelcontextprotocol.io/specification/2025-03-26/basic/transports#streamable-http) protocol, enabling multiple clients on the local network to connect to a single server instance. The endpoint is available at `http://<host>:<port>/mcp`.
 
@@ -542,6 +549,9 @@ Query documentation directly from the command line. Useful for testing and debug
 ```bash
 # Query a package (use name@version format from 'context list')
 context query 'nextjs@16.0' 'middleware authentication'
+
+# A bare name queries the highest installed version
+context query nextjs 'middleware authentication'
 
 # Returns the same JSON format as the MCP get_docs tool
 ```

--- a/packages/context/src/cli.test.ts
+++ b/packages/context/src/cli.test.ts
@@ -7,6 +7,7 @@ import {
   parseRegistryPackage,
   resolveAllowedLibraries,
   resolveLlmsTxtUrls,
+  resolveRemoveTarget,
   suggestPackageNameFromUrl,
 } from "./cli.js";
 import type { PackageInfo } from "./store.js";
@@ -466,9 +467,9 @@ describe("resolveAllowedLibraries", () => {
     },
   ];
 
-  it("returns the set of matching names for valid specs", () => {
+  it("returns bare names and pinned keys for valid specs", () => {
     const result = resolveAllowedLibraries(["react", "next@15.0.4"], installed);
-    expect(result).toEqual(new Set(["react", "next"]));
+    expect(result).toEqual(new Set(["react", "next@15.0.4"]));
   });
 
   it("exits with an error when a name isn't installed", () => {
@@ -488,6 +489,25 @@ describe("resolveAllowedLibraries", () => {
     }
   });
 
+  it("accepts a pinned version that isn't the newest installed", () => {
+    // `store.list()` returns the highest version first, so the pinned one
+    // isn't the first match for its name.
+    const multi: PackageInfo[] = [
+      {
+        name: "react",
+        version: "19.0.0",
+        path: "/react@19.db",
+        sizeBytes: 0,
+        sectionCount: 0,
+      },
+      ...installed,
+    ];
+    // The pinned key keeps react@19.0.0 out of the session.
+    expect(resolveAllowedLibraries(["react@18.3.1"], multi)).toEqual(
+      new Set(["react@18.3.1"]),
+    );
+  });
+
   it("exits with an error when the pinned version doesn't match", () => {
     const exit = vi
       .spyOn(process, "exit")
@@ -503,5 +523,63 @@ describe("resolveAllowedLibraries", () => {
       exit.mockRestore();
       err.mockRestore();
     }
+  });
+});
+
+describe("resolveRemoveTarget", () => {
+  function pkg(name: string, version: string): PackageInfo {
+    return {
+      name,
+      version,
+      path: `/${name}@${version}.db`,
+      sizeBytes: 0,
+      sectionCount: 0,
+    };
+  }
+
+  const installed = [
+    pkg("occtswift", "1.15.9"),
+    pkg("occtswift", "1.15.10"),
+    pkg("react", "18.3.1"),
+  ];
+
+  it("removes the only installed version for a bare name", () => {
+    expect(resolveRemoveTarget("react", installed)).toEqual({
+      pkg: pkg("react", "18.3.1"),
+    });
+  });
+
+  it("refuses a bare name when several versions are installed", () => {
+    const result = resolveRemoveTarget("occtswift", installed);
+    expect(result).toEqual({
+      error: [
+        "Multiple versions of occtswift are installed: 1.15.9, 1.15.10",
+        "Specify one, e.g. `context remove occtswift@1.15.9`.",
+      ],
+    });
+  });
+
+  it("removes exactly the requested version", () => {
+    expect(resolveRemoveTarget("occtswift@1.15.9", installed)).toEqual({
+      pkg: pkg("occtswift", "1.15.9"),
+    });
+    expect(resolveRemoveTarget("occtswift@1.15.10", installed)).toEqual({
+      pkg: pkg("occtswift", "1.15.10"),
+    });
+  });
+
+  it("reports the installed versions when the pinned one is missing", () => {
+    expect(resolveRemoveTarget("occtswift@1.15.11", installed)).toEqual({
+      error: [
+        "Package not found: occtswift@1.15.11",
+        "Installed versions: 1.15.9, 1.15.10",
+      ],
+    });
+  });
+
+  it("reports unknown names", () => {
+    expect(resolveRemoveTarget("missing", installed)).toEqual({
+      error: ["Package not found: missing"],
+    });
   });
 });

--- a/packages/context/src/cli.ts
+++ b/packages/context/src/cli.ts
@@ -55,8 +55,10 @@ import { type SearchResult, search } from "./search.js";
 import { ContextServer } from "./server.js";
 import {
   getPackageFileName,
+  isAllowedLibrary,
   type PackageInfo,
   PackageStore,
+  packageKey,
   readPackageInfo,
 } from "./store.js";
 
@@ -367,9 +369,12 @@ async function addFromWebsite(
 
     const sizeBytes = statSync(outputPath).size;
 
-    console.log(
-      `\nInstalled: ${packageName}@${versionLabel} (${formatBytes(sizeBytes)}, ${result.sectionCount} sections)`,
-    );
+    reportInstalled({
+      name: packageName,
+      version: versionLabel,
+      sizeBytes,
+      sectionCount: result.sectionCount,
+    });
     return;
   }
 
@@ -427,9 +432,12 @@ async function addFromWebsite(
 
   const sizeBytes = statSync(outputPath).size;
 
-  console.log(
-    `\nInstalled: ${packageName}@${versionLabel} (${formatBytes(sizeBytes)}, ${result.sectionCount} sections)`,
-  );
+  reportInstalled({
+    name: packageName,
+    version: versionLabel,
+    sizeBytes,
+    sectionCount: result.sectionCount,
+  });
 }
 
 const LOW_DOCS_THRESHOLD = 50;
@@ -511,6 +519,34 @@ function loadPackages(store: PackageStore): void {
   }
 }
 
+/**
+ * Report a finished install.
+ *
+ * Also flags when a higher version is already installed, because bare-name
+ * lookups resolve to it — otherwise installing an older version looks like a
+ * no-op when the user later queries by name.
+ */
+function reportInstalled(pkg: {
+  name: string;
+  version: string;
+  sizeBytes: number;
+  sectionCount: number;
+}): void {
+  console.log(
+    `\nInstalled: ${packageKey(pkg)} (${formatBytes(pkg.sizeBytes)}, ${pkg.sectionCount} sections)`,
+  );
+
+  const store = new PackageStore();
+  loadPackages(store);
+  const preferred = store.get(pkg.name);
+  if (!preferred || preferred.version === pkg.version) return;
+
+  console.log(
+    `Note: ${packageKey(preferred)} is also installed and stays the default for \`${pkg.name}\`.`,
+  );
+  console.log(`      Query this one as \`${packageKey(pkg)}\`.`);
+}
+
 /** Parse a `--libs` spec into name (optionally with @version). */
 // Uses lastIndexOf so scoped names like `@trpc/server@1.0.0` split correctly,
 // while a bare scoped name `@trpc/server` (leading `@` only) keeps its name.
@@ -533,19 +569,25 @@ export function resolveAllowedLibraries(
 
   for (const raw of specs) {
     const spec = parseLibSpec(raw);
-    const pkg = installed.find((p) => p.name === spec.name);
+    // Every installed version counts: pinning `react@18` must succeed even
+    // when a newer react is installed alongside it.
+    const matches = installed.filter((p) => p.name === spec.name);
 
-    if (!pkg) {
+    if (matches.length === 0) {
       errors.push(`  - ${raw}: not installed`);
       continue;
     }
-    if (spec.version && pkg.version !== spec.version) {
-      errors.push(
-        `  - ${raw}: installed version is ${pkg.version}, not ${spec.version}`,
-      );
+    if (spec.version && !matches.some((p) => p.version === spec.version)) {
+      const versions = matches.map((p) => p.version).join(", ");
+      const installedLabel =
+        matches.length > 1
+          ? `installed versions are ${versions}`
+          : `installed version is ${versions}`;
+      errors.push(`  - ${raw}: ${installedLabel}, not ${spec.version}`);
       continue;
     }
-    allowed.add(pkg.name);
+    // A pinned entry allows only that version; a bare name allows all of them.
+    allowed.add(spec.version ? `${spec.name}@${spec.version}` : spec.name);
   }
 
   if (errors.length > 0) {
@@ -591,9 +633,7 @@ function addFromFile(source: string, options: { save?: string }): void {
     savePackageCopy(destPath, options.save, info.name, info.version);
   }
 
-  console.log(
-    `\nInstalled: ${info.name}@${info.version} (${formatBytes(info.sizeBytes)}, ${info.sectionCount} sections)`,
-  );
+  reportInstalled(info);
 }
 
 /** Install a package from a URL. */
@@ -637,9 +677,7 @@ async function addFromUrl(
       savePackageCopy(destPath, options.save, info.name, info.version);
     }
 
-    console.log(
-      `\nInstalled: ${info.name}@${info.version} (${formatBytes(info.sizeBytes)}, ${info.sectionCount} sections)`,
-    );
+    reportInstalled(info);
   } catch (err) {
     // Clean up temp file on error
     if (existsSync(tempPath)) {
@@ -869,9 +907,12 @@ async function addFromGitClone(
 
     const sizeBytes = statSync(outputPath).size;
 
-    console.log(
-      `\nInstalled: ${packageName}@${versionLabel} (${formatBytes(sizeBytes)}, ${result.sectionCount} sections)`,
-    );
+    reportInstalled({
+      name: packageName,
+      version: versionLabel,
+      sizeBytes,
+      sectionCount: result.sectionCount,
+    });
 
     warnIfLowDocs(result.sectionCount, packageName);
   } finally {
@@ -946,9 +987,12 @@ async function addFromLocalDir(
 
   const sizeBytes = statSync(outputPath).size;
 
-  console.log(
-    `\nInstalled: ${packageName}@${versionLabel} (${formatBytes(sizeBytes)}, ${result.sectionCount} sections)`,
-  );
+  reportInstalled({
+    name: packageName,
+    version: versionLabel,
+    sizeBytes,
+    sectionCount: result.sectionCount,
+  });
 
   warnIfLowDocs(result.sectionCount, packageName);
 }
@@ -1043,6 +1087,48 @@ program
     );
   });
 
+/**
+ * Pick the package `context remove <spec>` should delete.
+ *
+ * `remove` deletes a file from disk, so a bare name is refused while several
+ * versions are installed rather than guessing which one the user meant. With a
+ * single version installed the bare name still works, as it always has.
+ */
+export function resolveRemoveTarget(
+  spec: string,
+  installed: PackageInfo[],
+): { pkg: PackageInfo } | { error: string[] } {
+  const { name, version } = parseLibSpec(spec);
+  const matches = installed.filter((p) => p.name === name);
+  const versions = matches.map((p) => p.version).join(", ");
+
+  if (matches.length === 0) {
+    return { error: [`Package not found: ${name}`] };
+  }
+
+  if (!version) {
+    const [only, ...rest] = matches;
+    if (!only) return { error: [`Package not found: ${name}`] };
+    if (rest.length > 0) {
+      return {
+        error: [
+          `Multiple versions of ${name} are installed: ${versions}`,
+          `Specify one, e.g. \`context remove ${packageKey(only)}\`.`,
+        ],
+      };
+    }
+    return { pkg: only };
+  }
+
+  const exact = matches.find((p) => p.version === version);
+  if (!exact) {
+    return {
+      error: [`Package not found: ${spec}`, `Installed versions: ${versions}`],
+    };
+  }
+  return { pkg: exact };
+}
+
 program
   .command("remove")
   .description("Remove a documentation package")
@@ -1051,24 +1137,21 @@ program
     const store = new PackageStore();
     loadPackages(store);
 
-    // Strip version suffix if present (e.g., "next@v16.2.0" -> "next")
-    const atIndex = name.indexOf("@");
-    const packageName = atIndex > 0 ? name.slice(0, atIndex) : name;
-
-    const pkg = store.get(packageName);
-    if (!pkg) {
-      console.error(`Error: Package not found: ${packageName}`);
+    const target = resolveRemoveTarget(name, store.list());
+    if ("error" in target) {
+      console.error(`Error: ${target.error[0]}`);
+      for (const line of target.error.slice(1)) console.error(line);
       process.exit(1);
     }
 
     // Delete file from disk
     try {
-      unlinkSync(pkg.path);
+      unlinkSync(target.pkg.path);
     } catch {
       // Ignore deletion errors
     }
 
-    console.log(`Removed: ${pkg.name}@${pkg.version}`);
+    console.log(`Removed: ${packageKey(target.pkg)}`);
   });
 
 program
@@ -1097,7 +1180,7 @@ program
         : undefined;
 
       const visible = allowedLibraries
-        ? store.list().filter((p) => allowedLibraries.has(p.name))
+        ? store.list().filter((p) => isAllowedLibrary(p, allowedLibraries))
         : store.list();
 
       if (visible.length > 0) {
@@ -1126,10 +1209,6 @@ program
       }
     },
   );
-
-function formatLibraryName(pkg: PackageInfo): string {
-  return `${pkg.name}@${pkg.version}`;
-}
 
 function formatSearchResult(result: SearchResult): string {
   if (result.results.length === 0) {
@@ -1166,10 +1245,10 @@ program
     loadPackages(store);
 
     const packages = store.list();
-    const pkg = packages.find((p) => formatLibraryName(p) === library);
+    const pkg = store.get(library);
 
     if (!pkg) {
-      const available = packages.map(formatLibraryName);
+      const available = packages.map(packageKey);
       if (available.length === 0) {
         console.error("Error: No packages installed.");
         console.error("Run: context add <package.db>");
@@ -1184,7 +1263,7 @@ program
       process.exit(1);
     }
 
-    const db = store.openDb(pkg.name);
+    const db = store.openDb(packageKey(pkg));
     if (!db) {
       console.error(`Error: Failed to open package database: ${library}`);
       process.exit(1);
@@ -1338,9 +1417,7 @@ program
           targetVersion,
         );
 
-        console.log(
-          `\nInstalled: ${info.name}@${info.version} (${formatBytes(info.sizeBytes)}, ${info.sectionCount} sections)`,
-        );
+        reportInstalled(info);
       } catch (err) {
         console.error(`Error: ${err instanceof Error ? err.message : err}`);
         process.exit(1);

--- a/packages/context/src/cli.ts
+++ b/packages/context/src/cli.ts
@@ -50,7 +50,11 @@ import {
   SEARCH_PACKAGES_NAME_DESCRIPTION,
 } from "./guidance.js";
 import { fetchLinkedDocs } from "./llms-txt.js";
-import { buildPackage, type MarkdownFile } from "./package-builder.js";
+import {
+  type BuildResult,
+  buildPackage,
+  type MarkdownFile,
+} from "./package-builder.js";
 import { type SearchResult, search } from "./search.js";
 import { ContextServer } from "./server.js";
 import {
@@ -360,8 +364,7 @@ async function addFromWebsite(
       );
     }
 
-    console.log(`✓ Built package: ${packageName}@${versionLabel}`);
-    console.log(`✓ Saved to ${outputPath}`);
+    reportBuilt(result, packageName, versionLabel, outputPath);
 
     if (options.save) {
       savePackageCopy(outputPath, options.save, packageName, versionLabel);
@@ -422,8 +425,7 @@ async function addFromWebsite(
     );
   }
 
-  console.log(`✓ Built package: ${packageName}@${versionLabel}`);
-  console.log(`✓ Saved to ${outputPath}`);
+  reportBuilt(result, packageName, versionLabel, outputPath);
 
   // Save to custom path if specified
   if (options.save) {
@@ -526,6 +528,29 @@ function loadPackages(store: PackageStore): void {
  * lookups resolve to it — otherwise installing an older version looks like a
  * no-op when the user later queries by name.
  */
+/**
+ * Report a freshly built package.
+ *
+ * Skipped files are surfaced rather than counted silently: a file too malformed
+ * to split or parse is dropped on its own so one bad document can't fail the
+ * build, which is only safe if the user can see it happened.
+ */
+function reportBuilt(
+  result: BuildResult,
+  name: string,
+  version: string,
+  outputPath: string,
+): void {
+  console.log(`✓ Built package: ${name}@${version}`);
+  console.log(`✓ Saved to ${outputPath}`);
+
+  if (result.skippedFiles > 0) {
+    console.log(
+      `⚠️  Skipped ${result.skippedFiles} file(s) that could not be parsed`,
+    );
+  }
+}
+
 function reportInstalled(pkg: {
   name: string;
   version: string;
@@ -897,8 +922,7 @@ async function addFromGitClone(
       sourceUrl: url,
     });
 
-    console.log(`✓ Built package: ${packageName}@${versionLabel}`);
-    console.log(`✓ Saved to ${outputPath}`);
+    reportBuilt(result, packageName, versionLabel, outputPath);
 
     // Save to custom path if specified
     if (options.save) {
@@ -977,8 +1001,7 @@ async function addFromLocalDir(
     sourceUrl: dirPath,
   });
 
-  console.log(`✓ Built package: ${packageName}@${versionLabel}`);
-  console.log(`✓ Saved to ${outputPath}`);
+  reportBuilt(result, packageName, versionLabel, outputPath);
 
   // Save to custom path if specified
   if (options.save) {

--- a/packages/context/src/server.ts
+++ b/packages/context/src/server.ts
@@ -18,7 +18,12 @@ import {
   SEARCH_PACKAGES_NAME_DESCRIPTION,
 } from "./guidance.js";
 import { type SearchResult, search } from "./search.js";
-import type { PackageInfo, PackageStore } from "./store.js";
+import {
+  isAllowedLibrary,
+  type PackageInfo,
+  type PackageStore,
+  packageKey,
+} from "./store.js";
 
 const require = createRequire(import.meta.url);
 const { version } = require("../package.json") as { version: string };
@@ -57,7 +62,8 @@ export class ContextServer {
   private visiblePackages(): PackageInfo[] {
     const all = this.store.list();
     if (!this.allowedLibraries) return all;
-    return all.filter((p) => this.allowedLibraries?.has(p.name));
+    const allowed = this.allowedLibraries;
+    return all.filter((p) => isAllowedLibrary(p, allowed));
   }
 
   /**
@@ -192,7 +198,7 @@ export class ContextServer {
       return z.string().describe(GET_DOCS_LIBRARY_DESCRIPTION);
     }
 
-    const libraryEnum = packages.map(formatLibraryName);
+    const libraryEnum = packages.map(packageKey);
     return z
       .enum(libraryEnum as [string, ...string[]])
       .describe(GET_DOCS_LIBRARY_DESCRIPTION);
@@ -250,7 +256,7 @@ export class ContextServer {
     topic: string,
   ): { content: { type: "text"; text: string }[] } {
     const packages = this.visiblePackages();
-    const pkg = packages.find((p) => formatLibraryName(p) === library);
+    const pkg = packages.find((p) => packageKey(p) === library);
 
     if (!pkg) {
       return {
@@ -266,7 +272,7 @@ export class ContextServer {
       };
     }
 
-    const db = this.store.openDb(pkg.name);
+    const db = this.store.openDb(packageKey(pkg));
     if (!db) {
       return {
         content: [
@@ -417,10 +423,6 @@ export class ContextServer {
       },
     );
   }
-}
-
-function formatLibraryName(pkg: PackageInfo): string {
-  return `${pkg.name}@${pkg.version}`;
 }
 
 function formatSearchResult(result: SearchResult): string {

--- a/packages/context/src/store.test.ts
+++ b/packages/context/src/store.test.ts
@@ -2,8 +2,20 @@ import { existsSync, mkdirSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, beforeAll, beforeEach, describe, expect, it } from "vitest";
-import { initDatabase, openDatabase } from "./database.js";
-import { getPackageFileName, PackageStore, readPackageInfo } from "./store.js";
+import {
+  type DatabaseConnection,
+  initDatabase,
+  openDatabase,
+} from "./database.js";
+import { getMetaValue } from "./db.js";
+import {
+  compareVersions,
+  getPackageFileName,
+  isAllowedLibrary,
+  type PackageInfo,
+  PackageStore,
+  readPackageInfo,
+} from "./store.js";
 import { createTestDb, insertChunk, rebuildFtsIndex } from "./test-utils.js";
 
 const TEST_DIR = join(tmpdir(), `context-test-${Date.now()}`);
@@ -179,6 +191,161 @@ describe("store", () => {
 
       expect(store.get("unknown")).toBeNull();
       expect(store.openDb("unknown")).toBeNull();
+    });
+  });
+
+  describe("PackageStore with several versions installed", () => {
+    /** Fake package info — these tests never touch the database file. */
+    function fake(name: string, version: string): PackageInfo {
+      return {
+        name,
+        version,
+        path: `/${name}@${version}.db`,
+        sizeBytes: 1,
+        sectionCount: 1,
+      };
+    }
+
+    // The reported case: 1.15.10 must win over 1.15.9 even though it sorts
+    // lower as text, and regardless of the order readdirSync returns files in.
+    it.each([
+      ["oldest first", ["1.15.9", "1.15.10"]],
+      ["newest first", ["1.15.10", "1.15.9"]],
+    ])("resolves a bare name to the highest version (%s)", (_label, order) => {
+      const store = new PackageStore();
+      for (const version of order) store.add(fake("occtswift", version));
+
+      expect(store.get("occtswift")?.version).toBe("1.15.10");
+    });
+
+    it("resolves name@version to that exact version", () => {
+      const store = new PackageStore();
+      store.add(fake("occtswift", "1.15.9"));
+      store.add(fake("occtswift", "1.15.10"));
+
+      expect(store.get("occtswift@1.15.9")?.version).toBe("1.15.9");
+      expect(store.get("occtswift@1.15.11")).toBeNull();
+    });
+
+    it("lists every installed version, highest first", () => {
+      const store = new PackageStore();
+      store.add(fake("occtswift", "1.15.9"));
+      store.add(fake("occtswift", "1.15.10"));
+      store.add(fake("react", "18.0.0"));
+
+      expect(store.list().map((p) => `${p.name}@${p.version}`)).toEqual([
+        "occtswift@1.15.10",
+        "occtswift@1.15.9",
+        "react@18.0.0",
+      ]);
+    });
+
+    it("prefers a release over its prereleases", () => {
+      const store = new PackageStore();
+      store.add(fake("next", "16.0.0"));
+      store.add(fake("next", "16.0.0-canary.3"));
+
+      expect(store.get("next")?.version).toBe("16.0.0");
+      expect(store.get("next@16.0.0-canary.3")?.version).toBe(
+        "16.0.0-canary.3",
+      );
+    });
+
+    it("keeps unparseable versions below numeric ones", () => {
+      const store = new PackageStore();
+      store.add(fake("hono", "latest"));
+      store.add(fake("hono", "4.0.0"));
+
+      expect(store.get("hono")?.version).toBe("4.0.0");
+      expect(store.get("hono@latest")?.version).toBe("latest");
+    });
+
+    it("picks unparseable versions deterministically when nothing is numeric", () => {
+      const versions = ["main", "latest", "nightly"];
+      const forward = new PackageStore();
+      for (const v of versions) forward.add(fake("hono", v));
+      const reversed = new PackageStore();
+      for (const v of [...versions].reverse()) reversed.add(fake("hono", v));
+
+      expect(forward.get("hono")?.version).toBe("nightly");
+      expect(reversed.get("hono")?.version).toBe("nightly");
+    });
+
+    it("removes only the requested version", () => {
+      const store = new PackageStore();
+      store.add(fake("occtswift", "1.15.9"));
+      store.add(fake("occtswift", "1.15.10"));
+
+      expect(store.remove("occtswift@1.15.9")).toBe(true);
+      expect(store.list().map((p) => p.version)).toEqual(["1.15.10"]);
+
+      // A bare name removes the version it resolves to.
+      expect(store.remove("occtswift")).toBe(true);
+      expect(store.list()).toHaveLength(0);
+    });
+
+    it("opens the database of the requested version", () => {
+      const oldPath = join(TEST_DIR, "test-lib@1.15.9.db");
+      const newPath = join(TEST_DIR, "test-lib@1.15.10.db");
+      createTestPackage(oldPath, { name: "test-lib", version: "1.15.9" });
+      createTestPackage(newPath, { name: "test-lib", version: "1.15.10" });
+
+      const store = new PackageStore();
+      store.add(readPackageInfo(oldPath));
+      store.add(readPackageInfo(newPath));
+
+      const pinned = store.openDb("test-lib@1.15.9");
+      expect(pinned).not.toBeNull();
+      expect(getMetaValue(pinned as DatabaseConnection, "version")).toBe(
+        "1.15.9",
+      );
+      pinned?.close();
+
+      const preferred = store.openDb("test-lib");
+      expect(getMetaValue(preferred as DatabaseConnection, "version")).toBe(
+        "1.15.10",
+      );
+      preferred?.close();
+    });
+  });
+
+  describe("isAllowedLibrary", () => {
+    const pkg = { name: "react", version: "18.3.1" };
+
+    it("matches a bare name and an exact key", () => {
+      expect(isAllowedLibrary(pkg, new Set(["react"]))).toBe(true);
+      expect(isAllowedLibrary(pkg, new Set(["react@18.3.1"]))).toBe(true);
+    });
+
+    it("rejects a key pinned to another version", () => {
+      expect(isAllowedLibrary(pkg, new Set(["react@19.0.0"]))).toBe(false);
+    });
+  });
+
+  describe("compareVersions", () => {
+    it("compares segments numerically, not as text", () => {
+      expect(compareVersions("1.15.9", "1.15.10")).toBeLessThan(0);
+      expect(compareVersions("1.15.10", "1.15.9")).toBeGreaterThan(0);
+      expect(compareVersions("2.0.0", "10.0.0")).toBeLessThan(0);
+    });
+
+    it("treats missing segments as zero and accepts a v prefix", () => {
+      expect(compareVersions("1.2", "1.3.0")).toBeLessThan(0);
+      expect(compareVersions("v1.3.0", "1.2.0")).toBeGreaterThan(0);
+      // Numerically equal versions still order deterministically, both ways.
+      expect(compareVersions("1.2", "1.2.0")).toBeLessThan(0);
+      expect(compareVersions("1.2.0", "1.2")).toBeGreaterThan(0);
+    });
+
+    it("sorts prereleases below their release", () => {
+      expect(compareVersions("2.0.0-rc.1", "2.0.0")).toBeLessThan(0);
+      expect(compareVersions("2.0.0-rc.1", "2.0.0-rc.2")).toBeLessThan(0);
+    });
+
+    it("sorts unparseable versions below numeric ones without throwing", () => {
+      expect(compareVersions("latest", "0.0.1")).toBeLessThan(0);
+      expect(compareVersions("0.0.1", "main")).toBeGreaterThan(0);
+      expect(compareVersions("latest", "main")).toBeLessThan(0);
     });
   });
 });

--- a/packages/context/src/store.ts
+++ b/packages/context/src/store.ts
@@ -22,38 +22,127 @@ export function getPackageFileName(name: string, version: string): string {
   return `${safeName}@${safeVersion}.db`;
 }
 
+/** Identity of an installed package, and the spec users type: `name@version`. */
+export function packageKey(pkg: PackageMeta): string {
+  return `${pkg.name}@${pkg.version}`;
+}
+
+/**
+ * Match a package against a `--libs` allow-list holding bare names (every
+ * installed version) and `name@version` keys (that version only).
+ */
+export function isAllowedLibrary(
+  pkg: PackageMeta,
+  allowed: ReadonlySet<string>,
+): boolean {
+  return allowed.has(pkg.name) || allowed.has(packageKey(pkg));
+}
+
+/** Numeric segments of a version plus its prerelease suffix, or null if not numeric. */
+function parseVersionParts(
+  version: string,
+): { numbers: number[]; prerelease: string } | null {
+  const core = version.startsWith("v") ? version.slice(1) : version;
+  const dash = core.indexOf("-");
+  const segments = (dash === -1 ? core : core.slice(0, dash)).split(".");
+  if (!segments.every((s) => /^\d+$/.test(s))) return null;
+
+  return {
+    numbers: segments.map((s) => Number.parseInt(s, 10)),
+    prerelease: dash === -1 ? "" : core.slice(dash + 1),
+  };
+}
+
+function compareText(a: string, b: string): number {
+  return a < b ? -1 : a > b ? 1 : 0;
+}
+
+/**
+ * Order two version strings, lowest first.
+ *
+ * Rules, all chosen so a bare-name lookup lands on the version a user expects:
+ * - segments compare as numbers, so `1.15.9` < `1.15.10` (text order gets this
+ *   backwards — the bug behind #102);
+ * - a missing segment counts as zero, so `1.2` and `1.2.0` are the same release;
+ * - a prerelease sorts below its release (`2.0.0-rc.1` < `2.0.0`); two
+ *   prereleases compare as text;
+ * - versions with no numeric part (`latest`, `main`) sort below every numeric
+ *   version, so a floating label never hides a real release;
+ * - anything still tied falls back to text, so results never depend on
+ *   insertion or filesystem order.
+ */
+export function compareVersions(a: string, b: string): number {
+  const partsA = parseVersionParts(a);
+  const partsB = parseVersionParts(b);
+  if (!partsA || !partsB) {
+    if (partsA) return 1;
+    if (partsB) return -1;
+    return compareText(a, b);
+  }
+
+  const length = Math.max(partsA.numbers.length, partsB.numbers.length);
+  for (let i = 0; i < length; i++) {
+    const diff = (partsA.numbers[i] ?? 0) - (partsB.numbers[i] ?? 0);
+    if (diff !== 0) return diff;
+  }
+
+  if (partsA.prerelease !== partsB.prerelease) {
+    if (!partsA.prerelease) return 1;
+    if (!partsB.prerelease) return -1;
+    return compareText(partsA.prerelease, partsB.prerelease);
+  }
+
+  return compareText(a, b);
+}
+
 /**
  * Registry of documentation packages.
  * Manages an in-memory list of packages without file system operations.
  */
 export class PackageStore {
+  // Keyed by `name@version`: several versions of the same package can be
+  // installed side by side, and each one has to stay addressable.
   private packages = new Map<string, PackageInfo>();
 
-  /** Add a package to the registry. */
+  /** Add a package to the registry. Replaces the same name@version only. */
   add(info: PackageInfo): void {
-    this.packages.set(info.name, info);
+    this.packages.set(packageKey(info), info);
   }
 
-  /** Remove a package from the registry by name. Returns true if removed. */
-  remove(name: string): boolean {
-    return this.packages.delete(name);
+  /** Remove a package resolved from `spec` (see `get`). Returns true if removed. */
+  remove(spec: string): boolean {
+    const pkg = this.get(spec);
+    if (!pkg) return false;
+    return this.packages.delete(packageKey(pkg));
   }
 
-  /** Get all registered packages. */
+  /** Get all registered packages, grouped by name with the highest version first. */
   list(): PackageInfo[] {
-    return [...this.packages.values()].sort((a, b) =>
-      a.name.localeCompare(b.name),
+    return [...this.packages.values()].sort(
+      (a, b) =>
+        a.name.localeCompare(b.name) || compareVersions(b.version, a.version),
     );
   }
 
-  /** Get a package by name. */
-  get(name: string): PackageInfo | null {
-    return this.packages.get(name) ?? null;
+  /**
+   * Get a package by spec: `name@version` returns that exact version, a bare
+   * `name` returns the highest installed version.
+   */
+  get(spec: string): PackageInfo | null {
+    const exact = this.packages.get(spec);
+    if (exact) return exact;
+
+    let best: PackageInfo | null = null;
+    for (const pkg of this.packages.values()) {
+      if (pkg.name !== spec) continue;
+      if (!best || compareVersions(pkg.version, best.version) > 0) best = pkg;
+    }
+    return best;
   }
 
-  /** Open a package database for searching. */
-  openDb(name: string): DatabaseConnection | null {
-    const pkg = this.packages.get(name);
+  /** Open a package database for searching. Accepts the same specs as `get`. */
+  openDb(spec: string): DatabaseConnection | null {
+    const pkg = this.get(spec);
     if (!pkg) return null;
     return openDatabase(pkg.path, { readonly: true });
   }

--- a/packages/registry/src/build.ts
+++ b/packages/registry/src/build.ts
@@ -159,7 +159,7 @@ export async function buildUnversioned(
   }
 
   // Git source: clone and read
-  const { tempDir, cleanup } = cloneRepository(source.url);
+  const { tempDir, cleanup } = cloneRepository(source.url, source.ref);
 
   try {
     // Get the commit SHA of the cloned HEAD

--- a/packages/registry/src/cli.ts
+++ b/packages/registry/src/cli.ts
@@ -7,7 +7,7 @@
 
 import { mkdirSync, rmSync } from "node:fs";
 import { resolve } from "node:path";
-import { isMissingRefError } from "@neuledge/context";
+import { type BuildResult, isMissingRefError } from "@neuledge/context";
 import { Command } from "commander";
 import {
   buildFromDefinition,
@@ -31,6 +31,19 @@ const DEFAULT_REGISTRY_DIR = resolve(
 const program = new Command()
   .name("registry")
   .description("Build context documentation packages from definitions");
+
+/**
+ * Describe a finished build.
+ *
+ * Skipped files are named rather than counted silently: a file too malformed to
+ * parse is dropped on its own so one bad document can't fail the build, which is
+ * only safe if the count reaches whoever is reading the log.
+ */
+function formatBuilt(result: BuildResult): string {
+  const skipped =
+    result.skippedFiles > 0 ? `, ${result.skippedFiles} files skipped` : "";
+  return `${result.sectionCount} sections, ${result.totalTokens} tokens${skipped}`;
+}
 
 program
   .command("list")
@@ -107,17 +120,13 @@ program
       }
       console.log(`Building ${def.registry}/${def.name}@${version}...`);
       const result = await buildFromDefinition(def, version, opts.output);
-      console.log(
-        `Built: ${result.path} (${result.sectionCount} sections, ${result.totalTokens} tokens)`,
-      );
+      console.log(`Built: ${result.path} (${formatBuilt(result)})`);
     } else {
       console.log(
         `Building ${def.registry}/${def.name}@latest (unversioned)...`,
       );
       const result = await buildUnversioned(def, opts.output);
-      console.log(
-        `Built: ${result.path} (${result.sectionCount} sections, ${result.totalTokens} tokens)`,
-      );
+      console.log(`Built: ${result.path} (${formatBuilt(result)})`);
     }
   });
 
@@ -156,9 +165,7 @@ program
 
       console.log(`Building ${def.registry}/${def.name}@${version}...`);
       const result = await buildFromDefinition(def, version, opts.output);
-      console.log(
-        `Built: ${result.path} (${result.sectionCount} sections, ${result.totalTokens} tokens)`,
-      );
+      console.log(`Built: ${result.path} (${formatBuilt(result)})`);
 
       console.log(`Publishing ${def.registry}/${def.name}@${version}...`);
       await publishPackage(def.registry, def.name, version, result.path);
@@ -184,9 +191,7 @@ program
         `Building ${def.registry}/${def.name}@latest (unversioned)...`,
       );
       const result = await buildUnversioned(def, opts.output);
-      console.log(
-        `Built: ${result.path} (${result.sectionCount} sections, ${result.totalTokens} tokens)`,
-      );
+      console.log(`Built: ${result.path} (${formatBuilt(result)})`);
 
       console.log(`Publishing ${def.registry}/${def.name}@latest...`);
       await publishPackage(def.registry, def.name, "latest", result.path);
@@ -246,9 +251,7 @@ program
               ver.version,
               opts.output,
             );
-            console.log(
-              `  Built (${result.sectionCount} sections, ${result.totalTokens} tokens)`,
-            );
+            console.log(`  Built (${formatBuilt(result)})`);
 
             console.log(`  Publishing...`);
             await publishPackage(
@@ -278,9 +281,7 @@ program
 
             console.log(`Building ${id}...`);
             const result = await buildUnversioned(def, opts.output);
-            console.log(
-              `  Built (${result.sectionCount} sections, ${result.totalTokens} tokens)`,
-            );
+            console.log(`  Built (${formatBuilt(result)})`);
 
             console.log(`  Publishing...`);
             await publishPackage(def.registry, def.name, "latest", result.path);

--- a/packages/registry/src/definition.test.ts
+++ b/packages/registry/src/definition.test.ts
@@ -324,6 +324,29 @@ source:
     expect(def.source.lang).toBe("en");
   });
 
+  it("parses an unversioned source pinned to a ref", () => {
+    // Needed for a project whose docs are no longer on the default branch —
+    // lucia's survive on v3 after the default branch was emptied.
+    const yaml = `
+name: lucia
+repository: https://github.com/lucia-auth/lucia
+source:
+  type: git
+  url: https://github.com/lucia-auth/lucia
+  ref: v3
+  docs_path: docs/pages
+`;
+    const npmDir = join(tempDir, "npm");
+    mkdirSync(npmDir);
+    writeFileSync(join(npmDir, "lucia.yaml"), yaml);
+
+    const def = loadDefinition(join(npmDir, "lucia.yaml"));
+
+    if (isVersioned(def)) throw new Error("expected unversioned");
+    expect(def.source.ref).toBe("v3");
+    expect(def.source.docs_path).toBe("docs/pages");
+  });
+
   it("rejects definition with both versions and source", () => {
     const yaml = `
 name: bad

--- a/packages/registry/src/definition.ts
+++ b/packages/registry/src/definition.ts
@@ -27,6 +27,13 @@ import { z } from "zod/v4";
 const GitSourceSchema = z.object({
   type: z.literal("git"),
   url: z.url(),
+  /**
+   * Branch or tag to build from, for unversioned sources only. Needed when the
+   * docs aren't on the default branch — an archived project whose maintained
+   * docs stayed behind on a release branch, say. Versioned entries resolve a
+   * tag per version and ignore this.
+   */
+  ref: z.string().optional(),
   docs_path: z.string().optional(),
   lang: z.string().default("en"),
 });

--- a/registry/npm/lucia.yaml
+++ b/registry/npm/lucia.yaml
@@ -2,7 +2,12 @@ name: lucia
 description: "Authentication resources for JavaScript and TypeScript"
 repository: https://github.com/lucia-auth/lucia
 
+# Lucia was deprecated in March 2025, and on 2026-07-30 the default branch was
+# emptied down to a README pointing at the announcement — which is what started
+# failing the daily build. The v3 docs are still on the v3 branch and plenty of
+# codebases still run v3, so build from there rather than dropping the package.
 source:
   type: git
   url: https://github.com/lucia-auth/lucia
-  docs_path: pages
+  ref: v3
+  docs_path: docs/pages


### PR DESCRIPTION
Three fixes. The middle one is time-sensitive: the daily registry update has been red since 2026-07-30 and will fail again at 06:00 UTC until it lands.

---

## 1. Every installed version of a package is addressable

Fixes #102, reported by @gsdali with an accurate root-cause analysis.

`PackageStore` keyed its map by bare package name, so `add()` overwrote on every call for the same name. With `pkg@1.15.9.db` and `pkg@1.15.10.db` both installed, whichever `readdirSync` returned last won. Bare-name lookup resolved to a filesystem-order-dependent version, and because `query` matched against `store.list()` — which only ever held one entry per name — `context query pkg@1.15.10` reported **"Package not found"** for a package sitting on disk.

The store now keys by `name@version`. A bare name resolves to the highest version, compared numerically: `1.15.9` vs `1.15.10` is exactly where string comparison inverts.

| | before | after |
|---|---|---|
| `context list` | `occtswift@1.15.9` only | both, newest first |
| `query occtswift@1.15.10` | `Package not found` | returns 1.15.10 |
| `query occtswift` | `Package not found` | resolves to 1.15.10 |
| `remove occtswift` | silently deleted 1.15.9 | refuses, deletes nothing |
| `remove occtswift@1.15.9` | deleted whatever the default was | deletes exactly 1.15.9 |

**Comparator.** The issue suggested reusing `compareVersions` from `git.ts`. It takes a `ParsedVersion` routed through `parseMonorepoTag` — git-tag semantics with no place in the store — and deliberately ignores prerelease, because `findLatestStableVersion` filters those out first. Reusing it would order `1.0.0-rc1` and `1.0.0` arbitrarily. So this adds a ~25-line string comparator in `store.ts`. Numeric segments compare as numbers, a prerelease sorts below its release, and a version with no numeric part (`latest`, `main`) sorts below every numeric one so a floating label can't hide a real release. Ties break on text, so nothing depends on insertion or filesystem order.

**`context remove` refuses a bare name when several versions are installed.** It unlinks a file, so guessing is the one outcome that loses data. A single installed version still works bare; a versioned argument now removes exactly that version, where the old code stripped `@version` and ignored it.

**`--libs` regression caught here.** The allow-list built a set of bare names, so once several versions became addressable, `--libs react@18` would also have exposed react@19.

## 2. The daily registry update is fixed

Red since 2026-07-30, four consecutive runs, one cause:

```
Succeeded: 36  Skipped: 8  Failed: 1
  npm/lucia@latest: Directory not found: /tmp/context-git-nltaOS/pages
```

Lucia was deprecated in March 2025, and on 2026-07-30 its default branch was emptied down to a README pointing at the announcement — so `pages` stopped existing. The v3 docs are still on the `v3` branch (105 markdown files), and plenty of codebases still run v3, so the definition pins there rather than dropping the package.

Unversioned git sources always built the default branch, so this adds an optional `ref` to the git source schema. `cloneRepository(url, ref?)` already accepted one; it was never plumbed through. Versioned entries resolve a tag per version and ignore it.

Verified end-to-end: `registry build lucia` yields **299 sections**.

## 3. Skipped files are reported

`buildPackage` counted files it dropped but nothing read the count, so a document too malformed to parse disappeared silently — the exact failure the count was added to prevent. Both CLIs now surface it.

---

```
pnpm lint    ✓
pnpm build   ✓
pnpm test    ✓  219 + 39 passed
```

Every new test was confirmed load-bearing by mutating the shipped code so exactly that test fails. The #102 scenario is asserted in **both insertion orders** — under the old bug, inserting oldest-first passes by luck, so a single-order test would have proved nothing.

## Worth a separate decision

A single dead upstream repo turning the whole nightly publish red is arguably the underlying problem — four nights of visibility lost to one deprecated package. Making `publish-all` exit zero when some packages succeed would fix that, but it changes the failure semantics of a publish pipeline, and the current strictness is how this got noticed. Left alone deliberately.