### PR TITLE
fix(registry): check the ref a package is built from, not HEAD

### DIFF
--- a/packages/registry/src/build.ts
+++ b/packages/registry/src/build.ts
@@ -38,8 +38,11 @@ export interface RegistryBuildResult extends BuildResult {
  * Get the HEAD commit SHA of a remote repository without cloning.
  * Uses `git ls-remote` which makes a single HTTP call.
  */
-export function getHeadCommit(url: string): string {
-  const output = execSync(`git ls-remote ${url} HEAD`, {
+export function getHeadCommit(url: string, ref?: string): string {
+  // Must match the ref the package is built from. Asking for HEAD while building
+  // a branch compares two unrelated commits, so the skip-if-unchanged check never
+  // fires and the package is rebuilt and republished on every run.
+  const output = execSync(`git ls-remote ${url} ${ref ?? "HEAD"}`, {
     encoding: "utf-8",
     stdio: ["pipe", "pipe", "pipe"],
   }).trim();

--- a/packages/registry/src/cli.ts
+++ b/packages/registry/src/cli.ts
@@ -178,7 +178,7 @@ program
         "latest",
       );
       if (existing?.source_commit && def.source.type === "git") {
-        const currentCommit = getHeadCommit(def.source.url);
+        const currentCommit = getHeadCommit(def.source.url, def.source.ref);
         if (currentCommit === existing.source_commit) {
           console.log(
             `Skipping ${def.registry}/${def.name}@latest (source unchanged: ${currentCommit.slice(0, 8)})`,
@@ -272,7 +272,10 @@ program
               "latest",
             );
             if (existing?.source_commit && def.source.type === "git") {
-              const currentCommit = getHeadCommit(def.source.url);
+              const currentCommit = getHeadCommit(
+                def.source.url,
+                def.source.ref,
+              );
               if (currentCommit === existing.source_commit) {
                 skipped++;
                 continue;


### PR DESCRIPTION
Follow-up to #105, which added `ref` to unversioned git sources and pinned lucia to its `v3` branch.

## The bug

`getHeadCommit(url)` always ran `git ls-remote <url> HEAD` — the default branch. Both skip-if-unchanged checks in `publish-all` called it without the ref, so a package built from a branch had its stored `source_commit` compared against a completely unrelated commit.

For lucia, measured against the real remote:

```
HEAD (main): c3c9f7ed
ref v3:      fc016ca8
```

Those can never be equal, so the skip never fires: lucia would be cloned, rebuilt and republished on every nightly run, forever, for a package whose docs have not changed since 2024. Not a failure — just permanent wasted work and an unnecessary republish of identical content each night.

## The fix

`getHeadCommit(url, ref?)` resolves the ref it is given, and both call sites pass `def.source.ref`. Behaviour for definitions without a `ref` is unchanged.

Verified against the real remote: the two calls now return different commits, and the one used for the check matches what `buildUnversioned` records.

```
pnpm lint    ✓
pnpm build   ✓
pnpm test    ✓  219 + 39 passed
```

No changeset — `@neuledge/registry` is `private: true`.

## How this was found

#105 merged without the adversarial review pass I'd planned, because the review agent died on a session limit and the nightly registry job had already failed five nights running. I judged the trade worth it and said so at the time. This is the defect that slipped through — found while confirming the lucia fix actually worked, not by the review that never ran.

Worth noting it is the *quiet* kind: everything goes green, nothing alerts, the registry just does redundant work indefinitely.

## Not covered

`getHeadCommit` has no unit test — it shells out to `git ls-remote`, and `packages/registry` has no test harness for `build.ts` or any network-touching code. Adding one means either a network-dependent test or mocking `execSync`, neither of which fits the existing test setup. Verified empirically against the live remote instead.

---
_Generated by [Claude Code](https://claude.ai/code/session_01NBQQpA86yYzwJUiVz8ph2R)_