### PR TITLE
fix(context): order prereleases and build metadata correctly

### DIFF
--- a/.changeset/brave-otters-argue.md
+++ b/.changeset/brave-otters-argue.md
@@ -1,0 +1,5 @@
+---
+"@neuledge/context": patch
+---
+
+Fix two cases where a bare package name resolved to the wrong installed version. With two prereleases installed, `2.0.0-rc.10` ranked below `2.0.0-rc.2`, because the prerelease suffix was compared as text — the same inversion that made `1.15.10` lose to `1.15.9`, one field deeper. Prerelease identifiers are now compared one at a time, numerically where both are numbers. Separately, a version carrying semver build metadata (`1.0.0+20130313144700`) was treated as having no numeric part at all and sorted below every real release, including `0.0.1`; build metadata is now ignored for ordering, as semver specifies.

--- a/packages/context/src/store.test.ts
+++ b/packages/context/src/store.test.ts
@@ -342,6 +342,25 @@ describe("store", () => {
       expect(compareVersions("2.0.0-rc.1", "2.0.0-rc.2")).toBeLessThan(0);
     });
 
+    it("compares prerelease identifiers numerically too", () => {
+      // Comparing the whole suffix as text puts rc.10 below rc.2 — the same
+      // inversion #102 was about, one field deeper.
+      expect(compareVersions("2.0.0-rc.2", "2.0.0-rc.10")).toBeLessThan(0);
+      expect(compareVersions("2.0.0-rc.10", "2.0.0-rc.2")).toBeGreaterThan(0);
+      // Non-numeric identifiers still compare as text, and a shorter run sorts lower.
+      expect(compareVersions("2.0.0-alpha.1", "2.0.0-beta.1")).toBeLessThan(0);
+      expect(compareVersions("2.0.0-rc", "2.0.0-rc.1")).toBeLessThan(0);
+    });
+
+    it("ignores build metadata rather than reading it as unparseable", () => {
+      // `1.0.0+build` left whole makes the last segment non-numeric, which used
+      // to drop the version below every real release.
+      expect(compareVersions("1.0.0+20130313144700", "0.0.1")).toBeGreaterThan(
+        0,
+      );
+      expect(compareVersions("1.0.0+build", "1.0.1")).toBeLessThan(0);
+    });
+
     it("sorts unparseable versions below numeric ones without throwing", () => {
       expect(compareVersions("latest", "0.0.1")).toBeLessThan(0);
       expect(compareVersions("0.0.1", "main")).toBeGreaterThan(0);

--- a/packages/context/src/store.ts
+++ b/packages/context/src/store.ts
@@ -42,7 +42,12 @@ export function isAllowedLibrary(
 function parseVersionParts(
   version: string,
 ): { numbers: number[]; prerelease: string } | null {
-  const core = version.startsWith("v") ? version.slice(1) : version;
+  const unprefixed = version.startsWith("v") ? version.slice(1) : version;
+  // Build metadata carries no ordering meaning (semver §10), but leaving it on
+  // makes the last segment non-numeric, which would drop the whole version into
+  // the floating-label bucket below every real release.
+  const plus = unprefixed.indexOf("+");
+  const core = plus === -1 ? unprefixed : unprefixed.slice(0, plus);
   const dash = core.indexOf("-");
   const segments = (dash === -1 ? core : core.slice(0, dash)).split(".");
   if (!segments.every((s) => /^\d+$/.test(s))) return null;
@@ -64,8 +69,10 @@ function compareText(a: string, b: string): number {
  * - segments compare as numbers, so `1.15.9` < `1.15.10` (text order gets this
  *   backwards — the bug behind #102);
  * - a missing segment counts as zero, so `1.2` and `1.2.0` are the same release;
- * - a prerelease sorts below its release (`2.0.0-rc.1` < `2.0.0`); two
- *   prereleases compare as text;
+ * - a prerelease sorts below its release (`2.0.0-rc.1` < `2.0.0`), and two
+ *   prereleases compare identifier by identifier, numerically where both are
+ *   numbers, so `rc.10` beats `rc.2`;
+ * - build metadata is ignored, since it carries no ordering meaning;
  * - versions with no numeric part (`latest`, `main`) sort below every numeric
  *   version, so a floating label never hides a real release;
  * - anything still tied falls back to text, so results never depend on
@@ -89,10 +96,36 @@ export function compareVersions(a: string, b: string): number {
   if (partsA.prerelease !== partsB.prerelease) {
     if (!partsA.prerelease) return 1;
     if (!partsB.prerelease) return -1;
-    return compareText(partsA.prerelease, partsB.prerelease);
+    return comparePrerelease(partsA.prerelease, partsB.prerelease);
   }
 
   return compareText(a, b);
+}
+
+/**
+ * Order two prerelease suffixes, lowest first.
+ *
+ * Dot-separated identifiers, compared one at a time: numeric ones as numbers, so
+ * `rc.10` beats `rc.2` — comparing the whole suffix as text reintroduces exactly
+ * the inversion #102 was about, one field deeper. A version that runs out of
+ * identifiers first sorts lower (`rc` < `rc.1`), per semver §11.
+ */
+function comparePrerelease(a: string, b: string): number {
+  const idsA = a.split(".");
+  const idsB = b.split(".");
+
+  for (let i = 0; i < Math.max(idsA.length, idsB.length); i++) {
+    const x = idsA[i];
+    const y = idsB[i];
+    if (x === undefined) return -1;
+    if (y === undefined) return 1;
+
+    const numeric = /^\d+$/.test(x) && /^\d+$/.test(y);
+    const diff = numeric ? Number(x) - Number(y) : compareText(x, y);
+    if (diff !== 0) return diff;
+  }
+
+  return 0;
 }
 
 /**


### PR DESCRIPTION
Two bugs in the version comparator shipped in `1.2.1`, found by an independent review of #105 run *after* it merged. Both make a bare package name resolve to the wrong installed version.

## 1. `2.0.0-rc.10` ranked below `2.0.0-rc.2`

```
installed: 2.0.0-rc.2, 2.0.0-rc.10
context query pkg   ->  serves 2.0.0-rc.2
```

Numeric segments were compared numerically, but the prerelease suffix still went through a plain text comparison — so `"rc.10" < "rc.2"`. That is precisely the inversion #102 was about, surviving one field deeper in the same function that fixed it.

Identifiers are now compared one at a time, numerically where both are numbers, with a shorter run sorting lower (semver §11).

## 2. `1.0.0+20130313144700` ranked below `0.0.1`

```
installed: 0.9.0, 1.0.0+20130313144700
context query pkg   ->  serves 0.9.0
```

Only a `-` prerelease was stripped before parsing, so build metadata left the last segment as `0+20130313144700`. That fails the numeric test, which classified the *entire version* as having no numeric part and dropped it into the bucket reserved for floating labels like `latest` — deliberately below every real release. A package installed at a semver-legal version became unreachable by bare name, silently serving older documentation.

Build metadata is now stripped before parsing, as it carries no ordering meaning (semver §10).

## Verification

Both reproduced against the shipped build before fixing, in both insertion orders, then confirmed fixed.

The comparator is still a total order — the property that keeps results independent of filesystem order, which was the whole point of #102:

```
24-version pool (leading zeros, v-prefix, >MAX_SAFE_INTEGER segments,
prereleases, build metadata, latest/main, empty, whitespace, non-ASCII)
  reflexivity   0 violations
  antisymmetry  0 violations
  transitivity  0 violations   (13,824 triples)
  list() drift  0 across 300 shuffles
```

Both new tests are mutation-verified: reverting the prerelease fix fails only the prerelease test, reverting the build-metadata fix fails only the build-metadata test.

```
pnpm lint    ✓
pnpm build   ✓
pnpm test    ✓  221 + 39 passed
```

## Why this exists

#105 merged without an independent review — the reviewer died on a session limit while a nightly job had been failing five nights, and I judged the trade worth it. This is the second batch of defects from that call; the first was #106. The review has now run against the shipped code, and it confirmed the rest is sound: no data loss in `context remove` (including scoped names like `@trpc/server`), `--libs` agrees across CLI and MCP server, and `openDb` cannot serve a different version than the caller resolved.

---
_Generated by [Claude Code](https://claude.ai/code/session_01NBQQpA86yYzwJUiVz8ph2R)_