### PR TITLE
fix(registry): retry transient registry-server faults

### DIFF
--- a/packages/registry/src/publish.test.ts
+++ b/packages/registry/src/publish.test.ts
@@ -1,0 +1,77 @@
+import { mkdtempSync, writeFileSync } from "node:fs";
+import { createServer, type Server } from "node:http";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import { checkPackageExists, publishPackage } from "./publish.js";
+
+/** A server that drops the first `failures` connections, then answers `status`. */
+function flakyServer(failures: number, status: number) {
+  let seen = 0;
+  const server = createServer((_req, res) => {
+    seen++;
+    if (seen <= failures) {
+      res.socket?.destroy();
+      return;
+    }
+    res.writeHead(status, { "Content-Type": "application/json" });
+    res.end("{}");
+  });
+
+  return new Promise<{ server: Server; url: string; hits: () => number }>(
+    (resolve) => {
+      server.listen(0, () => {
+        const address = server.address();
+        const port = typeof address === "object" && address ? address.port : 0;
+        resolve({
+          server,
+          url: `http://127.0.0.1:${port}`,
+          hits: () => seen,
+        });
+      });
+    },
+  );
+}
+
+describe("publish", () => {
+  let running: Server | undefined;
+
+  afterEach(() => {
+    running?.close();
+    running = undefined;
+  });
+
+  const dbPath = join(mkdtempSync(join(tmpdir(), "publish-test-")), "pkg.db");
+  writeFileSync(dbPath, "x");
+
+  // One dropped connection out of ~58 packages used to fail the whole nightly
+  // publish, so transient faults have to survive rather than abort the run.
+  it("retries a dropped connection instead of failing the package", async () => {
+    const { server, url, hits } = await flakyServer(2, 404);
+    running = server;
+    process.env.REGISTRY_SERVER_URL = url;
+    process.env.REGISTRY_PUBLISH_KEY = "test-key";
+
+    await expect(checkPackageExists("npm", "preact", "latest")).resolves.toBe(
+      null,
+    );
+    expect(hits()).toBe(3);
+  });
+
+  it("gives up immediately on a 4xx and keeps the server's message", async () => {
+    const server = createServer((_req, res) => {
+      res.writeHead(403);
+      res.end("bad key");
+    });
+    running = server;
+    await new Promise<void>((resolve) => server.listen(0, () => resolve()));
+    const address = server.address();
+    const port = typeof address === "object" && address ? address.port : 0;
+    process.env.REGISTRY_SERVER_URL = `http://127.0.0.1:${port}`;
+    process.env.REGISTRY_PUBLISH_KEY = "test-key";
+
+    await expect(
+      publishPackage("npm", "preact", "latest", dbPath),
+    ).rejects.toThrow(/403 Forbidden — bad key/);
+  });
+});

--- a/packages/registry/src/publish.ts
+++ b/packages/registry/src/publish.ts
@@ -7,8 +7,36 @@
  */
 
 import { readFileSync } from "node:fs";
+import pRetry, { AbortError } from "p-retry";
 
 const DEFAULT_SERVER_URL = "https://api.context.neuledge.com";
+
+/**
+ * The registry server occasionally drops a connection or returns 5xx under load.
+ * A single blip used to fail the whole nightly publish — 48 packages succeed and
+ * one `fetch failed` exits non-zero — so retry transient faults with backoff.
+ * 4xx is the server's considered answer and aborts immediately.
+ */
+function requestWithRetry(
+  url: string,
+  init: RequestInit,
+  describe: () => string,
+): Promise<Response> {
+  return pRetry(
+    async () => {
+      const response = await fetch(url, init);
+      if (response.ok || response.status === 404) return response;
+
+      const body = await response.text().catch(() => "");
+      const error = new Error(
+        `${describe()}: ${response.status} ${response.statusText}${body ? ` — ${body}` : ""}`,
+      );
+      if (response.status < 500) throw new AbortError(error);
+      throw error;
+    },
+    { retries: 3 },
+  );
+}
 
 function getServerUrl(): string {
   return process.env.REGISTRY_SERVER_URL?.trim() || DEFAULT_SERVER_URL;
@@ -48,16 +76,14 @@ export async function checkPackageExists(
     headers.Authorization = `Bearer ${key}`;
   }
 
-  const response = await fetch(url, { headers });
+  const response = await requestWithRetry(
+    url,
+    { headers },
+    () => `Server error checking ${registry}/${name}@${version}`,
+  );
 
   if (response.status === 404) {
     return null;
-  }
-
-  if (!response.ok) {
-    throw new Error(
-      `Server error checking ${registry}/${name}@${version}: ${response.status} ${response.statusText}`,
-    );
   }
 
   return (await response.json()) as PackageMetadata;
@@ -75,19 +101,19 @@ export async function publishPackage(
   const url = `${getServerUrl()}/packages/${encodeURIComponent(registry)}/${encodeURIComponent(name)}/${encodeURIComponent(version)}`;
   const body = readFileSync(dbPath);
 
-  const response = await fetch(url, {
-    method: "POST",
-    headers: {
-      Authorization: `Bearer ${getPublishKey()}`,
-      "Content-Type": "application/octet-stream",
+  // Re-uploading an identical package is safe: the server keys on
+  // registry/name/version, so a retry after a dropped connection overwrites
+  // rather than duplicating.
+  await requestWithRetry(
+    url,
+    {
+      method: "POST",
+      headers: {
+        Authorization: `Bearer ${getPublishKey()}`,
+        "Content-Type": "application/octet-stream",
+      },
+      body,
     },
-    body,
-  });
-
-  if (!response.ok) {
-    const text = await response.text().catch(() => "");
-    throw new Error(
-      `Failed to publish ${registry}/${name}@${version}: ${response.status} ${response.statusText}${text ? ` — ${text}` : ""}`,
-    );
-  }
+    () => `Failed to publish ${registry}/${name}@${version}`,
+  );
 }


### PR DESCRIPTION
Last night's nightly publish (run #165):

```
Succeeded: 48   Skipped: 9   Failed: 1
  npm/preact@latest: fetch failed
```

One dropped connection out of ~58 packages exits the run non-zero and leaves the registry a day stale. This is the second distinct cause of a red nightly this week — the first was a broken package definition (fixed in #105), and it was worth waiting to see what the *next* failure looked like before deciding how to harden the job.

## The gap

`version-check.ts` already retries public-registry calls with exponential backoff via `p-retry`. The two fetches to our **own** registry server, in `publish.ts`, had no retry at all — so a transient fault on either the existence check or the upload killed the package, and with it the run.

Both now go through the same pattern: 5xx and network faults retry, 4xx aborts immediately because that is the server's considered answer rather than a blip. No new dependency; `p-retry` is already used a file away.

Publishing is safe to retry — the server keys on `registry/name/version`, so a retry after a dropped connection overwrites rather than duplicating.

## Why not just stop failing the run

I considered making `publish-all` exit zero when some packages succeed, and rejected it. The pipeline reported the lucia breakage correctly for five straight nights; nobody was watching. Exiting zero would mean a genuinely broken definition is never noticed at all — trading a loud, fixable failure for silent rot. Retrying the transient class while still failing loudly on the permanent class targets the actual problem.

## Verification

Against a local server that drops the first two connections and then answers:

```
checkPackageExists: survived 2 dropped connections -> null
publishPackage:     survived 2 dropped connections -> resolved
403 aborts after 1 attempt: "Failed to publish npm/x@1: 403 Forbidden — forbidden"
```

Both new tests are mutation-verified: setting `retries: 0` fails only the retry test; removing the `AbortError` branch fails only the 4xx test (it hangs through the full backoff, then throws the wrong shape).

Error messages also now carry the server's response body on both paths — the existence check previously discarded it, which is what turned this outage into the bare string "fetch failed".

```
pnpm lint    ✓
pnpm build   ✓
pnpm test    ✓  221 + 41 passed
```

No changeset — `@neuledge/registry` is `private: true`.

---
_Generated by [Claude Code](https://claude.ai/code/session_01NBQQpA86yYzwJUiVz8ph2R)_