### PR TITLE
docs: require a PR claim before executing a plan

### DIFF
--- a/INSTRUCTIONS.md
+++ b/INSTRUCTIONS.md
@@ -62,6 +62,21 @@ Store in `/.plans/` with date prefix (e.g., `2026-01-27-feature-name.md`).
 
 When starting a task, review existing plans in `/.plans/` to find relevant context.
 
+### Claim a Plan Before Executing It
+
+A plan sitting in `/.plans/` is not evidence that nobody is working on it. Sessions
+run concurrently and cannot see each other, so before executing a plan:
+
+1. Search open **and recently closed** PRs for the plan's filename.
+2. If one references it, the plan is claimed — do not execute it. Review or extend
+   that PR instead.
+3. If none does, name the plan file in your PR body so the next session sees your claim.
+4. Delete the plan file in the same PR that completes it.
+
+Why: duplicate PRs have twice been opened because a plan sat unclaimed while two
+sessions independently picked it up and built the same thing. The PR is the only
+state both sessions can see, so the claim has to live there.
+
 ### Task Management
 
 Plans are **living documents** that evolve as understanding grows:


### PR DESCRIPTION
## Summary

Adds a claim step to the plan protocol in `INSTRUCTIONS.md`.

A plan file sitting in `/.plans/` carries no signal that a session is already working on it, and concurrent sessions can't see each other. Twice now that has meant two sessions independently picking up the same plan and opening duplicate PRs for identical work.

The PR list is the one piece of state every session can see, so the claim lives there:

1. Before executing a plan, search open **and recently closed** PRs for the plan's filename.
2. If one references it, the plan is claimed — review or extend that PR instead.
3. If none does, name the plan file in your PR body so the next session sees your claim.
4. Delete the plan file in the same PR that completes it.

The same rule is being added to `moshest/neuledge-internal`, where both duplicate incidents happened.

## Test plan

Docs-only change — no code paths touched, no changeset needed.

- [x] `pnpm lint` passes
- [x] `pnpm build` succeeds
- [x] `pnpm test` passes

---
_Generated by [Claude Code](https://claude.ai/code/session_01NBQQpA86yYzwJUiVz8ph2R)_