### PR TITLE
chore: add changeset for the defuddle security bump

### DIFF
--- a/.changeset/lucky-pandas-smile.md
+++ b/.changeset/lucky-pandas-smile.md
@@ -1,0 +1,5 @@
+---
+"@neuledge/context": patch
+---
+
+Update `defuddle` to 0.19.3, fixing GHSA-jg4p-g6xj-4qmf (XSS via unescaped attribute interpolation in site extractors). This affects HTML documentation sources; earlier versions pulled in the vulnerable 0.17.0.


### PR DESCRIPTION
## Summary

#118 fixed GHSA-jg4p-g6xj-4qmf (XSS in `defuddle` ≤0.19.0) but merged without a changeset, so it will not trigger a version bump.

That matters more than the usual missing-changeset case: no bump means no npm release, and the lockfile change only protects people building from this repo. Anyone installing `@neuledge/context` from npm keeps resolving the vulnerable `defuddle@0.17.0` until a new version ships.

This adds the `patch` changeset so the fix actually reaches users.

## Test plan

Changeset-only change — no code touched.

- [x] `pnpm lint` passes
- [x] `pnpm build` succeeds
- [x] `pnpm test` passes (verified on #118's tree before merge: 221 tests)

---
_Generated by [Claude Code](https://claude.ai/code/session_01NBQQpA86yYzwJUiVz8ph2R)_