### PR TITLE
fix(registry): stop sanity v4 releases failing the nightly publish

### DIFF
--- a/registry/npm/sanity.yaml
+++ b/registry/npm/sanity.yaml
@@ -2,8 +2,11 @@ name: sanity
 description: "Platform for structured content with a real-time API"
 repository: https://github.com/sanity-io/sanity
 
+# The v3 and v4 lines have no docs/ directory at all, and Sanity still ships v4
+# maintenance releases — each one failed the whole nightly publish with
+# "Directory not found: .../docs". docs/ only exists from v5 onward.
 versions:
-  - min_version: "3.0.0"
+  - min_version: "5.0.0"
     source:
       type: git
       url: https://github.com/sanity-io/sanity


### PR DESCRIPTION
## Summary

The nightly registry publish failed on **Aug 20 and Aug 21**:

```
npm/sanity@4.22.1: Directory not found: /tmp/context-git-dUIB0B/docs
Succeeded: 43  Skipped: 11  Failed: 1
```

One failed definition exits the whole run non-zero, so all 140 packages were affected.

**The run went green again on Aug 22, but nothing had been fixed.** `publish-all --since 2` only selects versions published in the last two days; once 4.22.1 aged out of that window it stopped being built and the error disappeared. The next v4 release would have failed identically.

## Root cause

The definition declared `min_version: "3.0.0"`, but `docs/` only exists from v5 onward. Sanity maintains v4, v5 and v6 in parallel and still ships v4 maintenance releases, so any of them hits a missing directory.

| Tag | Files in `docs/` | Build |
|---|---|---|
| v6.11.0 | 3 | 31 sections |
| v5.31.2 | 2 | 23 sections |
| v4.22.1 | 0 | **fails** |
| v3.99.0 | 0 | would fail |

## Fix

Raise the floor to `5.0.0`. Verified locally: 6.11.0 and 5.31.2 build; 4.22.1 now returns `No version entry matches 4.22.1 in sanity`, and `version-check.ts:96` filters unmatched versions out *before* the build rather than throwing — so the nightly skips it cleanly instead of failing.

## Worth a follow-up (not in this PR)

Even where it works, this package is thin: `docs/` holds 3 internal developer notes (`CORE_CONCEPTS.md`, `STEGA.md`, `TELEMETRY.md`), not Sanity's user documentation, which lives at sanity.io/docs. By `registry/README.md`'s own rule of thumb — "a few hundred sections means `docs_path` is right; a handful usually means it's pointing at the wrong directory" — 31 sections says this is the wrong source.

Sanity publishes an `llms.txt` (`https://www.sanity.io/llms.txt` returns 200), but registry definitions only support `git` and `zip` sources, so pointing at it needs a new source type rather than a config change.

## Test plan

- [x] `registry build sanity 6.11.0` → 31 sections
- [x] `registry build sanity 5.31.2` → 23 sections
- [x] `registry build sanity 4.22.1` → cleanly excluded
- [x] Definition change only; no code touched

---
_Generated by [Claude Code](https://claude.ai/code/session_01NBQQpA86yYzwJUiVz8ph2R)_