### PR TITLE
fix(context): only skip repo-meta filenames at the scan root

### DIFF
--- a/.changeset/lucky-pugs-repeat.md
+++ b/.changeset/lucky-pugs-repeat.md
@@ -1,0 +1,5 @@
+---
+"@neuledge/context": patch
+---
+
+Only skip repo-meta filenames (`security`, `license`, `changelog`, `contributing`, …) at the scan root, not at every depth. A documentation page that happens to share one of those names was being dropped silently: `context add` on the forgejo docs lost `docs/admin/actions/security.md`, the only source in the repo for `container.valid_volumes`, and reported success. `docker/docs` and `excalidraw/excalidraw` lose pages to the same rule.

--- a/packages/context/src/git.test.ts
+++ b/packages/context/src/git.test.ts
@@ -1,9 +1,13 @@
-import { describe, expect, it } from "vitest";
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import {
   findLatestStableVersion,
   isMissingRefError,
   isTransientGitError,
   parseMonorepoTag,
+  readLocalDocsFiles,
 } from "./git.js";
 
 describe("isTransientGitError", () => {
@@ -187,5 +191,44 @@ describe("findLatestStableVersion", () => {
       const tags = ["v1.2.3", "v1.2.10", "v1.2.9"];
       expect(findLatestStableVersion(tags)).toBe("v1.2.10");
     });
+  });
+});
+
+describe("readLocalDocsFiles — repo-meta filenames", () => {
+  let dir: string;
+
+  beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), "ctx-localdocs-"));
+  });
+
+  afterEach(() => {
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  const write = (rel: string, body: string): void => {
+    const full = join(dir, rel);
+    mkdirSync(join(full, ".."), { recursive: true });
+    writeFileSync(full, body);
+  };
+
+  it("skips repo-meta files at the scan root", () => {
+    write("security.md", "# Security policy\n\nReport issues to us.\n");
+    write("license.md", "# License\n\nMIT.\n");
+    write("guide.md", "# Guide\n\nContent.\n");
+
+    const paths = readLocalDocsFiles(dir).map((f) => f.path);
+
+    expect(paths).toEqual(["guide.md"]);
+  });
+
+  it("keeps a documentation page that merely shares a repo-meta filename", () => {
+    write(
+      "admin/actions/security.md",
+      "# Securing Actions\n\nThe default value of valid_volumes is an empty array.\n",
+    );
+
+    const paths = readLocalDocsFiles(dir).map((f) => f.path);
+
+    expect(paths).toEqual(["admin/actions/security.md"]);
   });
 });

--- a/packages/context/src/git.ts
+++ b/packages/context/src/git.ts
@@ -474,7 +474,11 @@ function findMarkdownFiles(
           const matchingExt = DOCUMENTATION_EXTENSIONS.find((ext) =>
             lowerName.endsWith(ext),
           );
-          if (matchingExt) {
+          // Only at the scan root: these names mean repo housekeeping there, but
+          // deeper in a docs tree they are ordinary pages — forgejo's
+          // docs/admin/actions/security.md documents Actions security, and was
+          // being dropped as if it were a SECURITY.md policy file.
+          if (matchingExt && basePath === "") {
             const baseName = lowerName.slice(0, -matchingExt.length);
             if (IGNORED_FILES.has(baseName)) continue;
           }


### PR DESCRIPTION
## The problem

`IGNORED_FILES` in `packages/context/src/git.ts` is matched by basename at **every depth**, not just at the scan root. The set is repo-root housekeeping — `security`, `license`, `changelog`, `contributing`, `history`, `code_of_conduct`, `claude`, and the two issue templates — but applied recursively it silently drops ordinary documentation pages that happen to share one of those names.

The build reports success either way. `context add` prints `Found N markdown files` and exits 0, so the only symptom is a later query returning nothing, which is indistinguishable from a query that simply has no answer.

## Measured

Against `@neuledge/context` 1.2.3, on a fresh clone of `codeberg.org/forgejo/docs`:

```
138 markdown files under docs/
135 reach the builder
```

The two lost files are `docs/admin/actions/security.md` and `docs/user/actions/security.md` — the pages documenting how to secure Forgejo Actions. The first is the **only** source in the repository for `container.valid_volumes`, so `context query forgejo valid_volumes` returned nothing at all.

After this change, the same query returns:

> **Securing Forgejo Actions Deployments > Job Containers with Docker (part 2)** — *"The default value of `valid_volumes` is an empty array `[]`. If an administrator changes this, they will allow a job container or service container to mount the listed volumes…"*

Package: 130 → 132 documents, 728 → 742 sections.

## Not just forgejo

Checked every repository I have a package for, via the GitHub trees API:

| repo | dropped by this rule |
|---|---|
| `docker/docs` | `content/manuals/extensions/extensions-sdk/architecture/security.md`, `content/manuals/billing/history.md`, `content/manuals/compose/intro/history.md`, `content/reference/api/dvp/changelog.md`, `content/reference/api/hub/changelog.md` |
| `excalidraw/excalidraw` | `dev-docs/docs/introduction/contributing.mdx` |
| `reactjs/react.dev`, `spf13/cobra` | nothing outside `.github/` |
| `golang/go` | only vendored subtrees |

## The change

Apply `IGNORED_FILES` only when `basePath === ""`. That is the case the set was written for, and it leaves nested pages alone. Six lines in `git.ts`.

Two tests, both written before the change and both mutation-checked:

- `skips repo-meta files at the scan root` — reddens if the filter is disabled entirely.
- `keeps a documentation page that merely shares a repo-meta filename` — reddens if the `basePath === ""` guard is removed.

`pnpm test` is green (223/223) and biome is clean.

## What this deliberately does not change

`docs/license.md` in the forgejo repo still gets skipped, because it sits at the scan root and genuinely is a licence. Link-only `index.md` pages are still dropped by `isTableOfContents`. Both are correct, and I checked them before assuming the whole gap was one bug.

One thing worth considering separately: a build that drops files could say so. A count of files found versus documents actually indexed, printed at the end, would have made this visible immediately rather than months later. Happy to open that as its own issue or PR if you'd like it.
