### PR TITLE
ci: make a clean maintenance-watch run show its work

### DIFF
--- a/.github/workflows/maintenance-watch.yml
+++ b/.github/workflows/maintenance-watch.yml
@@ -73,6 +73,7 @@ jobs:
           # two arrived and went unnoticed for two days.
           prs=$(api "https://api.github.com/repos/$REPO/pulls?state=open&per_page=50")
           expect_array "$prs" "open pull requests"
+          pr_count=$(echo "$prs" | jq '[.[] | select(.draft==false)] | length')
           stale=""
           for n in $(echo "$prs" | jq -r '.[] | select(.draft == false) | .number'); do
             opened=$(echo "$prs" | jq -r --argjson n "$n" '.[] | select(.number==$n) | .created_at')
@@ -117,6 +118,12 @@ jobs:
             findings="${findings}**Release drift**"$'\n'
             findings="${findings}- \`packages/context/package.json\` is ${local_v}, npm latest is ${npm_v}"$'\n\n'
           fi
+
+          # An all-clear has to show its work. "Nothing outstanding" with no
+          # detail is indistinguishable from a check that silently did nothing,
+          # which is the failure this workflow exists to replace.
+          echo "Examined ${pr_count} open PR(s); ${failed} of the last 7 scheduled" \
+               "registry runs failed (latest: ${latest}); version ${local_v} vs npm ${npm_v}."
 
           {
             echo "findings<<SWEEP_EOF"


### PR DESCRIPTION
## Summary

The first run of `maintenance-watch` (dispatched right after #130 merged) printed:

```
Nothing outstanding.
```

That was the **correct** answer — I checked each condition by hand afterwards:

- both open PRs (#125, #126) have non-bot replies, so neither is stale
- the Aug 20–21 nightly failures have aged out of the 7-run window
- `package.json` is 1.2.3 and npm latest is 1.2.3

But the output proves none of that. It's indistinguishable from a run whose checks silently did nothing — which is exactly the failure this workflow was added to replace, and the same shape as a nightly that goes green because a broken package aged out of `--since`.

## Change

Every run now logs what it examined:

```
Examined 2 open PR(s); 0 of the last 7 scheduled registry runs failed
(latest: success); version 1.2.3 vs npm 1.2.3.
```

An all-clear becomes auditable instead of asserted. If a future run reports `Examined 0 open PR(s)` while PRs are visibly open, that's a bug you can see rather than silence you have to trust.

## Test plan

- [x] YAML parses
- [x] Both `run` blocks pass `bash -n`
- [x] The counts come from data the job already fetched and shape-checked — no new API calls

Will dispatch once merged, same as #130, and confirm the line appears with real numbers.

---
_Generated by [Claude Code](https://claude.ai/code/session_01NBQQpA86yYzwJUiVz8ph2R)_