### PR TITLE
ci: build changed registry definitions on the pull request

### DIFF
--- a/.github/workflows/registry-validate.yml
+++ b/.github/workflows/registry-validate.yml
@@ -1,0 +1,111 @@
+name: Registry Validate
+
+# Builds the registry definitions a pull request adds or changes.
+#
+# ci.yml lints, builds and tests the TypeScript packages; nothing there reads
+# registry/*.yaml. A definition naming a branch or docs_path that does not
+# exist therefore passes review and CI, and first fails at 06:00 UTC in the
+# nightly registry-update — long after the PR that introduced it is merged and
+# out of mind. This closes that gap by building the changed definitions on the
+# pull request itself.
+#
+# Only changed definitions are built, so cost scales with the diff rather than
+# with the 113-and-growing registry.
+
+on:
+  pull_request:
+    branches:
+      - main
+    paths:
+      - 'registry/**/*.yaml'
+      - 'registry/**/*.yml'
+
+permissions: {}
+
+concurrency:
+  group: registry-validate-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  build-changed:
+    name: Build changed definitions
+    runs-on: ubuntu-latest
+    # A definition can pull a large documentation repository; godot builds
+    # ~8M tokens from 3.5k files. Generous, but bounded.
+    timeout-minutes: 45
+
+    permissions:
+      contents: read
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v6
+        with:
+          version: 10.27.0
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v7
+        with:
+          node-version: '22'
+          cache: 'pnpm'
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Build each changed definition
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+        run: |
+          set -euo pipefail
+
+          # Added or modified only: a deleted definition has nothing to build.
+          changed=$(git diff --name-only --diff-filter=AM "$BASE_SHA" "$HEAD_SHA" \
+                    -- 'registry/**/*.yaml' 'registry/**/*.yml')
+
+          if [ -z "$changed" ]; then
+            echo "No definition files added or modified."
+            exit 0
+          fi
+
+          echo "Changed definition files:"
+          echo "$changed" | sed 's/^/  /'
+          echo
+
+          failed=""
+          built=0
+
+          while IFS= read -r file; do
+            [ -n "$file" ] || continue
+
+            # The CLI selects by the definition's `name` field, which need not
+            # match the filename (registry/hex/phoenix.yaml is "phoenix").
+            name=$(sed -n 's/^name:[[:space:]]*//p' "$file" | head -1 | tr -d '"'"'"'' | tr -d '\r')
+            if [ -z "$name" ]; then
+              echo "::error file=$file::no top-level 'name:' field found"
+              failed="${failed} ${file}"
+              continue
+            fi
+
+            echo "::group::Building ${name} (${file})"
+            if pnpm --filter @neuledge/registry test-registry test "$name"; then
+              built=$((built + 1))
+              echo "::endgroup::"
+            else
+              echo "::endgroup::"
+              echo "::error file=$file::definition '${name}' failed to build"
+              failed="${failed} ${name}"
+            fi
+          done <<< "$changed"
+
+          echo
+          if [ -n "$failed" ]; then
+            echo "Failed to build:${failed}"
+            exit 1
+          fi
+          echo "Built ${built} definition(s) successfully."

--- a/registry/ci-probe-delete-me/ci-probe-delete-me.yaml
+++ b/registry/ci-probe-delete-me/ci-probe-delete-me.yaml
@@ -1,0 +1,8 @@
+name: ci-probe-delete-me
+description: "Temporary probe: points at a branch that does not exist. Registry Validate must go red on this. Reverted in the next commit."
+repository: https://github.com/godotengine/godot-docs
+source:
+  type: git
+  url: https://github.com/godotengine/godot-docs
+  ref: this-branch-does-not-exist-xyz
+  docs_path: tutorials/scripting/gdscript

--- a/registry/ci-probe-delete-me/ci-probe-delete-me.yaml
+++ b/registry/ci-probe-delete-me/ci-probe-delete-me.yaml
@@ -1,8 +1,0 @@
-name: ci-probe-delete-me
-description: "Temporary probe: points at a branch that does not exist. Registry Validate must go red on this. Reverted in the next commit."
-repository: https://github.com/godotengine/godot-docs
-source:
-  type: git
-  url: https://github.com/godotengine/godot-docs
-  ref: this-branch-does-not-exist-xyz
-  docs_path: tutorials/scripting/gdscript


### PR DESCRIPTION
## Why

`ci.yml` lints, builds and tests the TypeScript packages. **Nothing reads `registry/*.yaml`.**

So a definition naming a branch or `docs_path` that doesn't exist passes review and CI unchallenged, and first fails at 06:00 UTC in the nightly `registry-update` — after the PR that introduced it is merged and out of mind. Same shape as the sanity breakage that hid for four nights: the check that would have caught it ran nowhere near the change.

#133 made it concrete. Two new definitions arrived with **zero check runs**, so verifying them meant cloning the upstream repo and building both by hand.

## What it does

On a PR touching `registry/**/*.yaml`, builds each definition the PR adds or modifies via the existing `test-registry test <name>` CLI. Only changed definitions, so cost tracks the diff rather than the 113-definition registry. No new tooling — it runs the command a maintainer would run locally.

## Verification

This PR changes no registry files, so it cannot exercise its own workflow. Rather than merge on local component tests alone, I pushed a deliberate probe (commit `75ea47d`) adding a definition pointing at a nonexistent branch, then removed it (`856434f`). Both commits are kept rather than squashed so the evidence stays in the history.

The probe run failed exactly as required, and for the right reason rather than incidentally:

```
Changed definition files:
  registry/ci-probe-delete-me/ci-probe-delete-me.yaml

Error: Git clone failed: fatal: Remote branch
  this-branch-does-not-exist-xyz not found in upstream origin
##[error]definition 'ci-probe-delete-me' failed to build
Failed to build: ci-probe-delete-me
##[error]Process completed with exit code 1
```

That confirms the whole chain end to end: the `paths:` filter triggered, diff detection found the file, the name resolved, the build failed on the bad ref specifically, the error annotation fired, and the job exited non-zero.

Checked before that, locally:

- [x] Nonexistent `docs_path` → exits 1, rather than "succeeding" with an empty package. The failure mode worth ruling out, since a silent empty build would sail through a naive check
- [x] Name extraction handles a `name` differing from its filename (`registry/hex/phoenix.yaml` → `phoenix`), quoted names, and a missing `name:` field
- [x] Diff detection returns exactly the two files from #133 and excludes deletions
- [x] Both #133 definitions build: `gdscript` 129 sections / 60,921 tokens, `godot` 14,488 sections / 8,136,608 tokens
- [x] Lint, Build, Test green on the cleaned head

`permissions: {}` at top level with `contents: read` on the job; no secrets, so it works on fork PRs.

## Note on cost

`timeout-minutes: 45`. A definition can pull a large documentation repo — `godot` builds ~8M tokens from 3.5k files — so the ceiling is deliberately generous but bounded. If large-repo definitions become common, the thing worth deciding is a size budget, not the timeout; there's no documented ceiling in the registry today.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NBQQpA86yYzwJUiVz8ph2R