### PR TITLE
fix(registry): match scoped definition names on Windows

### DIFF
--- a/packages/registry/src/definition.test.ts
+++ b/packages/registry/src/definition.test.ts
@@ -171,6 +171,31 @@ versions:
     expect(def.versions[0].tag_pattern).toBe("@trpc/server@{version}");
   });
 
+  it("accepts a scoped path that uses backslash separators", () => {
+    // On Windows relative() returns "@apollo\\client", which never matched the
+    // "@apollo/client" in the file, so listDefinitions() threw for every scoped
+    // definition. Reproduced here by putting a literal backslash in the filename:
+    // on Linux that is one filename rather than a separator, but the string
+    // reaching the comparison is byte-identical to what Windows produces.
+    const yaml = `
+name: "@apollo/client"
+description: "Apollo Client"
+source:
+  type: git
+  url: https://github.com/apollographql/apollo-client
+  docs_path: docs
+`;
+    const npmDir = join(tempDir, "npm");
+    mkdirSync(npmDir, { recursive: true });
+    const filePath = join(npmDir, "@apollo\\client.yaml");
+    writeFileSync(filePath, yaml);
+
+    const def = loadDefinition(filePath, npmDir);
+
+    expect(def.name).toBe("@apollo/client");
+    expect(def.registry).toBe("npm");
+  });
+
   it("throws when scoped name doesn't match path", () => {
     const yaml = `
 name: "@trpc/client"

--- a/packages/registry/src/definition.ts
+++ b/packages/registry/src/definition.ts
@@ -167,8 +167,15 @@ export function loadDefinition(
   // Derive expected name from relative path within managerDir
   // e.g., npm/@trpc/server.yaml → @trpc/server
   // e.g., npm/next.yaml → next
+  //
+  // relative() returns platform separators, so on Windows a scoped definition
+  // yields "@apollo\\client" and never matches the "@apollo/client" in the file.
+  // Normalising unconditionally rather than only when sep is "\\" keeps one code
+  // path on every platform, so Linux CI exercises the same comparison Windows does.
   const expectedName = managerDir
-    ? relative(managerDir, filePath).replace(/\.yaml$/, "")
+    ? relative(managerDir, filePath)
+        .replace(/\.yaml$/, "")
+        .replaceAll("\\", "/")
     : basename(filePath, ".yaml");
 
   // Allow filesystem-safe encoding: colons in names are replaced with underscores


### PR DESCRIPTION
## The bug

`loadDefinition` derives the expected name from `relative(managerDir, filePath)`, which returns **platform separators**. On Windows a scoped definition yields `@apollo\client`, which never matches the `@apollo/client` inside the file:

```
Definition name "@apollo/client" doesn't match filename "@apollo\client.yaml"
```

`listDefinitions()` loads every definition, so one scoped package throws and **no registry command runs at all** on Windows.

Reported by @TeeJS in #133. They reproduced it on `main` with their own definitions removed, confirmed it doesn't affect Linux CI, and deliberately left it unfixed to keep that PR to one concern. Credit to them — this is their find and their proposed approach.

## The fix

Normalise the derived name to forward slashes before comparing.

They suggested `split(sep).join("/")`, which is correct. I used `.replaceAll("\\", "/")` instead for one reason: `sep` is `/` on Linux, so `split(sep)` leaves backslashes untouched and the Windows behaviour becomes a branch that **no Linux CI run ever executes**. Normalising unconditionally keeps a single code path on both platforms, so the comparison Linux tests is the comparison Windows runs.

## Test

The regression test reproduces the failure **on Linux**. A literal backslash in a filename is one filename here rather than a separator, but the string reaching the comparison is byte-identical to what Windows produces from a real separator.

Verified in both directions rather than assumed:

- [x] **Without** the fix, the new test fails with the exact reported error: `Definition name "@apollo/client" doesn't match filename "@apollo\client.yaml"`
- [x] **With** the fix, it passes
- [x] `pnpm lint` clean (needed `pnpm fix` for wrapping), `pnpm build` clean
- [x] `pnpm test` — 221 context + 49 registry, all passing

No changeset: `@neuledge/registry` is `private: true`, and CLAUDE.md scopes changesets to published packages.

## Scope

The fix and its test only. The Windows path-separator artifact in `doc_path` values that @TeeJS also mentioned is a different thing — a display artifact in built output rather than a hard failure — and isn't touched here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NBQQpA86yYzwJUiVz8ph2R

---
_Generated by [Claude Code](https://claude.ai/code/session_01NBQQpA86yYzwJUiVz8ph2R)_