### PR TITLE
feat(registry): add convex package definition

### DIFF
--- a/registry/npm/convex.yaml
+++ b/registry/npm/convex.yaml
@@ -1,0 +1,8 @@
+name: convex
+description: "The reactive backend-as-a-service for fullstack TypeScript apps"
+repository: https://github.com/get-convex/convex-backend
+
+source:
+  type: git
+  url: https://github.com/get-convex/convex-backend
+  docs_path: npm-packages/docs


### PR DESCRIPTION
Adds the package documentation definition for Convex (`npm/convex`) to the community registry.

Convex (`get-convex/convex-backend`) maintains its official documentation in the monorepo under `npm-packages/docs`. This unversioned definition tracks the documentation directly from the tip.

### Build Verification

Tested locally using the registry test tools:
- `pnpm --filter @neuledge/registry test-registry test convex`
  - Sections: 1,329
  - Tokens: 315,852
- `pnpm --filter @neuledge/registry registry build convex`
  - Result: `dist-packages/npm-convex@latest.db` built with 0 errors