### PR TITLE
feat(registry): add wrangler package definition

### DIFF
--- a/registry/npm/wrangler.yaml
+++ b/registry/npm/wrangler.yaml
@@ -1,0 +1,8 @@
+name: wrangler
+description: "Cloudflare Workers CLI and developer platform"
+repository: https://github.com/cloudflare/workers-sdk
+
+source:
+  type: git
+  url: https://github.com/cloudflare/cloudflare-docs
+  docs_path: src/content/docs/workers


### PR DESCRIPTION
Adds the package documentation definition for Cloudflare Workers (\
pm/wrangler\) to the community registry.

Cloudflare Workers (\cloudflare/cloudflare-docs\) hosts its developer platform documentation under \src/content/docs/workers\. This unversioned definition enables AI agents to query official Cloudflare Workers and Wrangler documentation directly via Context.

### Build Verification

Tested locally using the registry test tools:
- \pnpm --filter @neuledge/registry registry build wrangler\
  - Sections: 1,866
  - Tokens: 566,598
  - Result: \dist-packages/npm-wrangler@latest.db\ built with 0 errors